### PR TITLE
Fix encrypt command --add option

### DIFF
--- a/lib/travis/cli/encrypt.rb
+++ b/lib/travis/cli/encrypt.rb
@@ -33,7 +33,7 @@ module Travis
           keys          = config_key.split('.')
           last_key      = keys.pop
           nested_config = keys.inject(travis_config) { |c,k| c[k] ||= {}}
-          nested_config[last_key] ||= [] << { 'secret' => encrypted }
+          nested_config[last_key] ||= [] << { 'secure' => encrypted }
           File.write(travis_yaml, travis_config.to_yaml)
         else
           say encrypted.inspect, template(__FILE__)


### PR DESCRIPTION
According to the documentation (and what seems to work in my case), it should be `secure` instead of `secret`.

Cf http://about.travis-ci.org/docs/user/encryption-keys/
