### PR TITLE
Detect tracked repository for current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Again, like most other commands, goes well with shell scripting:
 
 Repository commands have all the options [General API Commands](#general-api-commands) have.
 
-Additionally, you can specify the Repository to talk to by providing `--repo owner/name`. However, if you invoke the command inside a clone of the project, the client will figure out this option on its own. Note that it uses the [git remote](http://www.kernel.org/pub/software/scm/git/docs/git-remote.html) "origin" to do so.
+Additionally, you can specify the Repository to talk to by providing `--repo owner/name`. However, if you invoke the command inside a clone of the project, the client will figure out this option on its own. Note that it uses the tracked [git remote](http://www.kernel.org/pub/software/scm/git/docs/git-remote.html) for the current branch (and defaults to 'origin' if no tracking is set) to do so.
 
 It will also automatically pick [Travis Pro](https://travis-ci.com) if it is a private project. You can of course override this decission with `--pro`, `--org` or `--api-endpoint URL`
 

--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -43,7 +43,11 @@ module Travis
         end
 
         def find_slug
-          git_info = `git config --get remote.origin.url 2>&1`
+          git_head = `git name-rev --name-only HEAD 2>&1`.chomp
+          git_remote = `git config --get branch.#{git_head}.remote 2>&1`.chomp
+          # Default to 'origin' if no tracking is set
+          git_remote = 'origin' if git_remote.empty?
+          git_info = `git config --get remote.#{git_remote}.url 2>&1`.chomp
           $1 if git_info =~ GIT_REGEX
         end
 


### PR DESCRIPTION
By default, the `travis` tool uses the `origin` remote. However, this branch may not exist. It would be useful it detected the tracked repository for the current branch instead.
