### PR TITLE
Add clear_cache(!) to Travis::Namespace

### DIFF
--- a/lib/travis/client/namespace.rb
+++ b/lib/travis/client/namespace.rb
@@ -31,6 +31,14 @@ module Travis
         alias find     find_one
         alias find_all find_many
 
+        def clear_cache
+          session.clear_cache
+        end
+
+        def clear_cache!
+          session.clear_cache!
+        end
+
         private
 
           def session


### PR DESCRIPTION
The README specifies that you can clear the cache for the global session
with `Travis.clear_cache`, but since this method is not in
`Travis::Namespace` you get a `NoMethodError` if you try to do that.
