### PR TITLE
Remove all whitespace from an encrypted string

### DIFF
--- a/lib/travis/client/repository.rb
+++ b/lib/travis/client/repository.rb
@@ -14,7 +14,7 @@ module Travis
 
         def encrypt(value)
           encrypted = to_rsa.public_encrypt(value)
-          Base64.encode64(encrypted).strip
+          Base64.encode64(encrypted).gsub(/\s+/, "")
         end
 
         def to_rsa


### PR DESCRIPTION
The whitespaces are all artifacts from the base64 encoding, but they don't actually contain any information and can be safely removed.
