### PR TITLE
Add typhoeus 0.5 dependency.

### DIFF
--- a/travis.gemspec
+++ b/travis.gemspec
@@ -153,7 +153,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gh"
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "pry",                   "~> 0.9"
-  s.add_dependency "typhoeus"
+  s.add_dependency "typhoeus",              "~> 0.5"
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
Typhoeus doesn't add the Faraday adapter used in [Travis::Client::Session](https://github.com/travis-ci/travis/blob/3d5e5f5841955339382278020a6a55c5fc46991a/lib/travis/client/session.rb#L5) until version [0.5.0](https://github.com/typhoeus/typhoeus/compare/v0.4.2...v0.5.0), so the CLI won't run with an older version.
