### PR TITLE
encrypt: Don't print the warning message if argument includes "="

### DIFF
--- a/lib/travis/cli/encrypt.rb
+++ b/lib/travis/cli/encrypt.rb
@@ -20,7 +20,7 @@ module Travis
         error "--override without --add makes no sense"  if override? and not add?
         self.override |= !config_key.start_with?('env.') if add?      and not append?
 
-        if args.first =~ %r{\w+/\w+}
+        if args.first =~ %r{\w+/\w+} && !args.first.include?("=")
           warn "WARNING: The name of the repository is now passed to the command with the -r option:"
           warn "    #{command("encrypt [...] -r #{args.first}")}"
           warn "  If you tried to pass the name of the repository as the first argument, you"
@@ -100,4 +100,3 @@ Please add the following to your <[[ color('.travis.yml', :info) ]]> file:
 %s
 
 Pro Tip: You can add it automatically by running with <[[ color('--add', :info) ]]>.
-

--- a/spec/cli/encrypt_spec.rb
+++ b/spec/cli/encrypt_spec.rb
@@ -35,4 +35,9 @@ describe Travis::CLI::Endpoint do
     run_cli('encrypt', 'rails/rails', 'foo').should be_success
     stderr.should match(/WARNING/)
   end
+
+  example "travis encrypt foo=foo/bar" do
+    run_cli("encrypt", "foo=foo/bar").should be_success
+    stderr.should_not match(/WARNING/)
+  end
 end


### PR DESCRIPTION
If the environment variable includes "/", the warning message about the
-r option is printed. As far as I know, "=" is not a legal character in the
reposiory slug (it'll be changed to -), so we can avoid printing the message
if the argument included a "=").
