### PR TITLE
unreverse body and title in growlnotify call

### DIFF
--- a/lib/travis/tools/notification.rb
+++ b/lib/travis/tools/notification.rb
@@ -46,7 +46,7 @@ module Travis
         end
 
         def notify(title, body)
-          system "%s -m %p %p >/dev/null" % [@command, title, body]
+          system "%s -m %p %p >/dev/null" % [@command, body, title]
         end
 
         def available?


### PR DESCRIPTION
Growl notifications currently get 'user/repo#123 started' in the title and 'Travis CI' in the body. This looks weird, and because Growl truncates titles (but not bodies) important information gets lost. This pull swaps title and body.
