### PR TITLE
set growl application name

### DIFF
--- a/lib/travis/tools/notification.rb
+++ b/lib/travis/tools/notification.rb
@@ -46,7 +46,7 @@ module Travis
         end
 
         def notify(title, body)
-          system "%s -m %p %p >/dev/null" % [@command, body, title]
+          system "%s -n Travis -m %p %p >/dev/null" % [@command, body, title]
         end
 
         def available?


### PR DESCRIPTION
By default, growlnotify sends notifications as app 'growlnotify'. Changing the application name to 'Travis' allows users to modify behaviour of Travis notifications (passing on notifications to other services, deciding if and how the popups stay on screen).

HOWEVER: if the user is running Growl 2.1, and their installed growlnotify binary is at 1.2, this pull will simply make notifications stop working. I suspect this is a bug in Growl and/or growlnotify, but it can be pretty annoying.

I feel people should just upgrade growlnotify with their Growl, but you may think different. Feel free to reject.
