### PR TITLE
avoid shell parsing

### DIFF
--- a/lib/travis/tools/notification.rb
+++ b/lib/travis/tools/notification.rb
@@ -46,7 +46,7 @@ module Travis
         end
 
         def notify(title, body)
-          system "%s -n Travis -m %p %p >/dev/null" % [@command, body, title]
+          system @command, '-n', 'Travis', '-m', body, title
         end
 
         def available?


### PR DESCRIPTION
%p does not safely escape for shell usage. The array form of system avoids the shell altogether and as such is safer.
