### PR TITLE
Show branch name for PRs

### DIFF
--- a/lib/travis/client/build.rb
+++ b/lib/travis/client/build.rb
@@ -26,7 +26,7 @@ module Travis
 
       def branch_info
         info = commit.branch
-        pull_request? ? info << " (PR ##{pr_number})" : info
+        pull_request? ? info + " (PR ##{pr_number})" : info
       end
 
       def pusher_channels


### PR DESCRIPTION
Right now, when a PR is active against a branch, we completely hide
the branch name. This can be disorienting.
