### PR TITLE
Flag libnotify notifications as transient

### DIFF
--- a/lib/travis/tools/notification.rb
+++ b/lib/travis/tools/notification.rb
@@ -57,7 +57,7 @@ module Travis
 
       class LibNotify
         def notify(title, body)
-          system 'notify-send', '--expire-time=10000', '-i', ICON, title, CGI.escapeHTML(body)
+          system 'notify-send', '--expire-time=10000', '-h', 'int:transient:1', '-i', ICON, title, CGI.escapeHTML(body)
         end
 
         def available?


### PR DESCRIPTION
This will make them vanish after the expire time.

In Gnome Shell this means they don't clutter the
message tray, but also won't expire if the user is
not active.

https://developer.gnome.org/notification-spec/#hints
