### PR TITLE
Updates travis.yml generation for cloudfoundry

### DIFF
--- a/lib/travis/cli/setup/cloud_foundry.rb
+++ b/lib/travis/cli/setup/cloud_foundry.rb
@@ -8,10 +8,10 @@ module Travis
 
         def run
           deploy 'provider' => 'cloudfoundry' do |config|
-            target_file = File.expand_path('.cf/target', Dir.home)
-            config['target']       ||= File.read(target_file).chomp if File.exist? target_file
-            config['target']       ||= ask("Cloud Foundry target: ").to_s
-            config['username']     ||= ask("Cloud Foundry user name: ").to_s
+            target_file = File.expand_path('.cf/config.json', Dir.home)
+            config['api']       ||= JSON.parse(File.read(target_file))["Target"] if File.exist? target_file
+            config['api']       ||= ask("Cloud Foundry api: ").to_s
+            config['username']     ||= ask("Cloud Foundry username: ").to_s
             config['password']     ||= ask("Cloud Foundry password: ") { |q| q.echo = "*" }.to_s
             config['organization'] ||= ask("Cloud Foundry organization: ").to_s
             config['space']        ||= ask("Cloud Foundry space: ").to_s


### PR DESCRIPTION
Hey All,

This updates the .travis.yml generation related to a change that was made in the dpl gem.  We just updated the way deploys are done and that has lead to a different dependency being installed (go cli tool).  I have updated the setup below to reflect the file structure changes for this new tool and also the change we made to rename "target" to "api".

Let me know if you have questions.  The edge release of travis dpl currently supports this structure.
