### PR TITLE
Update faraday dependency to 0.9

### DIFF
--- a/travis.gemspec
+++ b/travis.gemspec
@@ -243,7 +243,7 @@ Gem::Specification.new do |s|
   ]
 
   # dependencies
-  s.add_dependency "faraday",               "~> 0.8.7" # FIXME
+  s.add_dependency "faraday",               "~> 0.9"
   s.add_dependency "faraday_middleware",    "~> 0.9"
   s.add_dependency "highline",              "~> 1.6"
   s.add_dependency "backports"


### PR DESCRIPTION
faraday_middleware is now compatible with faraday 0.9 and typheous is too as of 0.6.8.

Closes #70.
