### PR TITLE
Added a mailmap to clean up authors on rubygems

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Konstantin Haase <konstantin.mailinglists@googlemail.com> Konstantin Haase <konstantin.haase@gmail.com>
+Henrik Hodne <me@henrikhodne.com> Henrik Hodne <henrik@hodne.io>
+joshua-anderson <j@zatigo.com> Joshua Anderson <j@zatigo.com>
+Peter Souter <p.morsou@gmail.com> petems <p.morsou@gmail.com>

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task :update => :completion do
 
   # fetch data
   fields = {
-    :authors => `git shortlog -sn`.b.scan(/[^\d\s].*/).map { |a| a == 'petems' ? 'Peter Souter' : a },
+    :authors => `git shortlog -sn`.b.scan(/[^\d\s].*/),
     :email   => `git shortlog -sne`.b.scan(/[^<]+@[^>]+/),
     :files   => `git ls-files`.b.split("\n").reject { |f| f =~ /^(\.|Gemfile)/ }
   }


### PR DESCRIPTION
A mail map combines authors and changes their names so that it looks correct with `git shortlog`. I used it to clean up the ruby gems author list.
