### PR TITLE
Fix Validation failed error using sshkey --upload

### DIFF
--- a/lib/travis/cli/sshkey.rb
+++ b/lib/travis/cli/sshkey.rb
@@ -76,7 +76,7 @@ module Travis
       end
 
       def remove_passphrase(value)
-        return unless Tools::SSLKey.has_passphrase? value
+        return value unless Tools::SSLKey.has_passphrase? value
         return Tools::SSLKey.remove_passphrase(value, passphrase) || error("wrong pass phrase") if passphrase
         error "Key is encrypted, but missing --passphrase option" unless interactive?
         say "The private key is protected by a pass phrase."


### PR DESCRIPTION
when using `travis sshkey --upload a_file` without a passpharse error ::

```
Validation failed (value: missing field, value: not a private key)
```

is raised as rsa_key is empty due to wrong empty return value
