### PR TITLE
Use ls-remote --get-url to get the git URI

### DIFF
--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -66,7 +66,7 @@ module Travis
           git_head    = `git name-rev --name-only HEAD 2>#{IO::NULL}`.chomp
           git_remote  = `git config --get branch.#{git_head}.remote 2>#{IO::NULL}`.chomp
           git_remote  = 'origin' if git_remote.empty?
-          git_info    = `git config --get remote.#{git_remote}.url 2>#{IO::NULL}`.chomp
+          git_info    = `git ls-remote --get-url #{git_remote} 2>#{IO::NULL}`.chomp
 
           if Addressable::URI.parse(git_info).path =~ GIT_REGEX
             detectected_slug = $1


### PR DESCRIPTION
Addresses GH #258

Using `url.<remote>.insteadOf`, one may create shorthand URLs (such as
`work:project` to stand in for `git@github.com:MyCompany/project`).  This
patch uses ls-remote to resolve the alias for such URLS to their
actual destination, which allows the gem to correctly determine the
slug for the repo.  `ls-remote --get-url` has been present since
Git v1.7.5, so hopefully that's old enough.