### PR TITLE
Define pre-commit hook to help projects run `travis lint`

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,0 +1,6 @@
+-   id: travis-lint
+    name: Travis YAML linter
+    description: This hook lints .travis.yml files.
+    entry: travis lint --skip-completion-check --skip-version-check --exit-code --
+    language: ruby
+    files: \.travis\.yml$


### PR DESCRIPTION
Howdy Travis folks!

[pre-commit](http://pre-commit.com/) is a system for managing git pre-commit hooks. Projects can define a `.pre-commit-config.yaml` file in their root directory containing a list of hooks to run on commit and during tests (including in Travis CI).

pre-commit handles installation and version management of hooks (linters, fixers, and other code quality checks) in several languages. For example, a Python project can easily use a Ruby SCSS linter, without every developer having to worry about installing a specific version of Ruby or a Ruby gem.

A lot of projects are actually running pre-commit on Travis. It would be super convenient if they could run travis-yaml to validate their .travis.yml file as part of their testing.

With this change, projects would just need to add:

```
- repo: https://github.com/travis-ci/travis.rb.git
  sha: 438c81fd718bf105d11da0e9f32dd4c353c04281
  hooks:
     - id: travis-lint
```

...to their existing `.pre-commit-config.yaml` file, and they would automatically be able to take advantage of travis lint any time they change their `travis.yml` file.

Here's an example of what it looks like from a developer's perspective:
![developer example](http://i.fluffy.cc/rzzgcmlRh2p0xm5B9QpkRL0G96DkclZR.png)

(Normally you wouldn't ever run pre-commit manually except in CI; the first line is just an example.)

Here's an example of a Travis run where a developer is using pre-commit: https://travis-ci.org/Yelp/pgctl/builds/72168253#L216

Would be really cool to add this hook definition. Happy to answer any questions you have!
