### PR TITLE
fix for outputting 'provider:' twice in .travis.yml

### DIFF
--- a/lib/travis/cli/setup/cloud_foundry.rb
+++ b/lib/travis/cli/setup/cloud_foundry.rb
@@ -7,7 +7,7 @@ module Travis
         description "automatic deployment to Cloud Foundry"
 
         def run
-          deploy 'provider' => 'cloudfoundry' do |config|
+          deploy 'cloudfoundry' do |config|
             target_file = File.expand_path('.cf/config.json', Dir.home)
             config['api']       ||= JSON.parse(File.read(target_file))["Target"] if File.exist? target_file
             config['api']       ||= ask("Cloud Foundry api: ").to_s


### PR DESCRIPTION
The 'travis setup cloudfoundry' command outputted
deploy:
  provider:
    provider: cloudfoundry