### PR TITLE
You require the devel package for native extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2017,7 +2017,7 @@ Ubuntu:
 
 Fedora:
 
-    $ sudo yum install ruby
+    $ sudo yum install ruby ruby-devel
 
 Arch Linux:
 


### PR DESCRIPTION
Otherwise you'll get an error:

```
Fetching: addressable-2.3.8.gem (100%)
Successfully installed addressable-2.3.8
Fetching: websocket-1.2.2.gem (100%)
Successfully installed websocket-1.2.2
Fetching: pusher-client-0.6.2.gem (100%)
Successfully installed pusher-client-0.6.2
Fetching: ffi-1.9.10.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing travis:
	ERROR: Failed to build gem native extension.

    /usr/bin/ruby -r ./siteconf20151015-22533-jsvu5t.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/share/include/ruby.h

extconf failed, exit code 1

Gem files will remain installed in /home/voor/.gem/ruby/gems/ffi-1.9.10 for inspection.
Results logged to /home/voor/.gem/ruby/extensions/x86_64-linux/ffi-1.9.10/gem_make.out

```