### PR TITLE
Change the config to upload_dir, as this is the one that is supported

### DIFF
--- a/lib/travis/cli/setup/s3.rb
+++ b/lib/travis/cli/setup/s3.rb
@@ -14,7 +14,7 @@ module Travis
             local_dir = ask("Local project directory to upload (Optional): ").to_s
             config['local-dir'] = local_dir unless local_dir.empty?
             upload_dir = ask("S3 upload directory (Optional): ").to_s
-            config['upload-dir'] = upload_dir unless upload_dir.empty?
+            config['upload_dir'] = upload_dir unless upload_dir.empty?
             config['acl'] = ask("S3 ACL Settings (private, public_read, public_read_write, authenticated_read, bucket_owner_read, bucket_owner_full_control): ").to_s { |q| q.default = 'private'}
             encrypt(config, 'secret_access_key') if agree("Encrypt secret access key? ") { |q| q.default = 'yes' }
           end


### PR DESCRIPTION
The supported configuration is `upload_dir` and **not** `upload-dir`.
This commit corrects the generation when using command `travis setup s3`
