### PR TITLE
Always set tags: true for Github Releases

### DIFF
--- a/lib/travis/cli/setup/releases.rb
+++ b/lib/travis/cli/setup/releases.rb
@@ -11,6 +11,8 @@ module Travis
           deploy 'releases' do |config|
             github.with_token { |t| config['api_key'] = t }
             config['file'] = ask("File to Upload: ").to_s
+            config['on'] ||= {}
+            config['on']['tags'] = true
           end
         end
 


### PR DESCRIPTION
Documentation already states that it is required. The code mirrors the behavior of the `on` question, but does so unconditionally.

fixes #329
