### PR TITLE
Fix InvalidURIError with git ssh remotes

### DIFF
--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -83,11 +83,13 @@ module Travis
         end
 
         def parse_remote(url)
-          URI.parse(url).path
-        rescue URI::InvalidURIError
-          path = url.split(':').last
-          path = "/#{path}" unless path.start_with?('/')
-          path
+          if url.start_with?('git@github.com:')
+            path = url.split(':').last
+            path = "/#{path}" unless path.start_with?('/')
+            path
+          else
+            URI.parse(url).path
+          end
         end
 
         def load_slug

--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -1,6 +1,5 @@
 require 'travis/cli'
 require 'yaml'
-require 'uri/ssh_git'
 
 module Travis
   module CLI
@@ -68,7 +67,7 @@ module Travis
           git_remote  = 'origin' if git_remote.empty?
           git_info    = `git ls-remote --get-url #{git_remote} 2>#{IO::NULL}`.chomp
 
-          if parse_remote(git_info).path =~ GIT_REGEX
+          if parse_remote(git_info) =~ GIT_REGEX
             detectected_slug = $1
             if interactive?
               if agree("Detected repository as #{color(detectected_slug, :info)}, is this correct? ") { |q| q.default = 'yes' }
@@ -83,10 +82,12 @@ module Travis
           end
         end
 
-        def parse_remote(remote)
-          URI.parse(remote)
+        def parse_remote(url)
+          URI.parse(url).path
         rescue URI::InvalidURIError
-          URI::SshGit.parse(remote)
+          path = url.split(':').last
+          path = "/#{path}" unless path.start_with?('/')
+          path
         end
 
         def load_slug

--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -83,7 +83,7 @@ module Travis
         end
 
         def parse_remote(url)
-          if url.start_with?('git@github.com:')
+          if url =~ /^git@[^:]+:/
             path = url.split(':').last
             path = "/#{path}" unless path.start_with?('/')
             path

--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -1,6 +1,6 @@
 require 'travis/cli'
 require 'yaml'
-require "addressable/uri"
+require 'uri/ssh_git'
 
 module Travis
   module CLI
@@ -68,7 +68,7 @@ module Travis
           git_remote  = 'origin' if git_remote.empty?
           git_info    = `git ls-remote --get-url #{git_remote} 2>#{IO::NULL}`.chomp
 
-          if Addressable::URI.parse(git_info).path =~ GIT_REGEX
+          if parse_remote(git_info).path =~ GIT_REGEX
             detectected_slug = $1
             if interactive?
               if agree("Detected repository as #{color(detectected_slug, :info)}, is this correct? ") { |q| q.default = 'yes' }
@@ -81,6 +81,12 @@ module Travis
               detectected_slug
             end
           end
+        end
+
+        def parse_remote(remote)
+          URI.parse(remote)
+        rescue URI::InvalidURIError
+          URI::SshGit.parse(remote)
         end
 
         def load_slug

--- a/spec/cli/repo_command_spec.rb
+++ b/spec/cli/repo_command_spec.rb
@@ -8,6 +8,11 @@ describe Travis::CLI::RepoCommand do
       path.should be == '/travis-ci/travis.rb.git'
     end
 
+    it 'handles GitHub Enterprise URIS' do
+      path = subject.send(:parse_remote, 'git@example.com:travis-ci/travis.rb.git')
+      path.should be == '/travis-ci/travis.rb.git'
+    end
+
     it 'handles HTTPS URIs' do
       path = subject.send(:parse_remote, 'https://github.com/travis-ci/travis.rb.git')
       path.should be == '/travis-ci/travis.rb.git'

--- a/spec/cli/repo_command_spec.rb
+++ b/spec/cli/repo_command_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'uri'
+
+describe Travis::CLI::RepoCommand do
+  describe '#parse_remote' do
+    it 'handles git@github.com URIs' do
+      path = subject.send(:parse_remote, 'git@github.com:travis-ci/travis.rb.git')
+      path.should be == '/travis-ci/travis.rb.git'
+    end
+
+    it 'handles HTTPS URIs' do
+      path = subject.send(:parse_remote, 'https://github.com/travis-ci/travis.rb.git')
+      path.should be == '/travis-ci/travis.rb.git'
+    end
+
+    it 'raises URI::InvalidURIError for invalid URIs' do
+      expect { subject.send(:parse_remote, "foo@example.com:baz/bar.git") }.to raise_error(URI::InvalidURIError)
+    end
+  end
+end

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -299,9 +299,6 @@ Gem::Specification.new do |s|
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.0")
-    s.add_dependency "addressable",           "~> 2.3", "< 2.4.0"
-  end
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -260,6 +260,7 @@ Gem::Specification.new do |s|
     "spec/cli/login_spec.rb",
     "spec/cli/logs_spec.rb",
     "spec/cli/open_spec.rb",
+    "spec/cli/repo_command_spec.rb",
     "spec/cli/restart_spec.rb",
     "spec/cli/setup_spec.rb",
     "spec/cli/show_spec.rb",

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -300,6 +300,9 @@ Gem::Specification.new do |s|
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_dependency "uri-ssh_git",           "~> 2.0"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.0")
+    s.add_dependency "addressable",           "~> 2.3", "< 2.4.0"
+  end
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -299,7 +299,6 @@ Gem::Specification.new do |s|
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
-  s.add_dependency "uri-ssh_git",           "~> 2.0"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9.0")
     s.add_dependency "addressable",           "~> 2.3", "< 2.4.0"
   end

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -299,7 +299,7 @@ Gem::Specification.new do |s|
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
-  s.add_dependency "addressable",           "~> 2.3"
+  s.add_dependency "uri-ssh_git",           "~> 2.0"
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
Replace addressable, which doesn't support ssh/git style URIs with a
combination of URI and URI::GitSsh to avoid errors when detecting the
slug from remotes.

Fixes #342