### PR TITLE
Upgrade to Rspec 3

### DIFF
--- a/spec/cli/cancel_spec.rb
+++ b/spec/cli/cancel_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Travis::CLI::Cancel do
   example 'travis cancel' do
-    run_cli('cancel', '-t', 'token').should be_success
-    $params['id'].should be == "4125095"
-    $params['entity'].should be == "builds"
+    expect(run_cli('cancel', '-t', 'token')).to be_success
+    expect($params['id']).to eq("4125095")
+    expect($params['entity']).to eq("builds")
   end
 
   example 'travis cancel 6180.1' do
-    run_cli('cancel', '6180.1', '-t', 'token').should be_success
-    $params['id'].should be == "4125096"
-    $params['entity'].should be == "jobs"
+    expect(run_cli('cancel', '6180.1', '-t', 'token')).to be_success
+    expect($params['id']).to eq("4125096")
+    expect($params['entity']).to eq("jobs")
   end
 end

--- a/spec/cli/encrypt_spec.rb
+++ b/spec/cli/encrypt_spec.rb
@@ -2,42 +2,42 @@ require 'spec_helper'
 
 describe Travis::CLI::Encrypt do
   example "travis encrypt foo" do
-    run_cli('encrypt', 'foo').should be_success
-    stdout.should match(/^".{60,}"\n$/)
+    expect(run_cli('encrypt', 'foo')).to be_success
+    expect(stdout).to match(/^".{60,}"\n$/)
   end
 
   example "travis encrypt foo -r rails/rails" do
-    run_cli('encrypt', 'foo', '-r', 'rails/rails').should be_success
-    stdout.should match(/^".{60,}"\n$/)
+    expect(run_cli('encrypt', 'foo', '-r', 'rails/rails')).to be_success
+    expect(stdout).to match(/^".{60,}"\n$/)
   end
 
   example "travis encrypt foo -i" do
-    run_cli('encrypt', 'foo', '-i', '--skip-completion-check', '-r', 'travis-ci/travis.rb').should be_success
-    stdout.should start_with("Please add the following to your .travis.yml file:\n\n  secure: ")
+    expect(run_cli('encrypt', 'foo', '-i', '--skip-completion-check', '-r', 'travis-ci/travis.rb')).to be_success
+    expect(stdout).to start_with("Please add the following to your .travis.yml file:\n\n  secure: ")
   end
 
   example "cat foo | travis encrypt" do
     run_cli('encrypt') { |i| i.puts('foo') }
-    stdout.should match(/\A".{60,}"\n\Z/)
+    expect(stdout).to match(/\A".{60,}"\n\Z/)
   end
 
   example "cat foo\\nbar | travis encrypt -s" do
     run_cli('encrypt', '-s') { |i| i.puts("foo\nbar") }
-    stdout.should match(/\A(".{60,}"\n){2}\Z/)
+    expect(stdout).to match(/\A(".{60,}"\n){2}\Z/)
   end
 
   example "cat foo\\nbar | travis encrypt" do
     run_cli('encrypt') { |i| i.puts("foo\nbar") }
-    stdout.should match(/\A".{60,}"\n\Z/)
+    expect(stdout).to match(/\A".{60,}"\n\Z/)
   end
 
   example "travis encrypt rails/rails foo" do
-    run_cli('encrypt', 'rails/rails', 'foo').should be_success
-    stderr.should match(/WARNING/)
+    expect(run_cli('encrypt', 'rails/rails', 'foo')).to be_success
+    expect(stderr).to match(/WARNING/)
   end
 
   example "travis encrypt foo=foo/bar" do
-    run_cli("encrypt", "foo=foo/bar").should be_success
-    stderr.should_not match(/WARNING/)
+    expect(run_cli("encrypt", "foo=foo/bar")).to be_success
+    expect(stderr).not_to match(/WARNING/)
   end
 end

--- a/spec/cli/endpoint_spec.rb
+++ b/spec/cli/endpoint_spec.rb
@@ -2,33 +2,33 @@ require 'spec_helper'
 
 describe Travis::CLI::Endpoint do
   example "travis endpoint" do
-    run_cli('endpoint').should be_success
-    stdout.should be == "https://api.travis-ci.org/\n"
+    expect(run_cli('endpoint')).to be_success
+    expect(stdout).to eq("https://api.travis-ci.org/\n")
   end
 
   example "travis endpoint --pro" do
-    run_cli('endpoint', '--pro').should be_success
-    stdout.should be == "https://api.travis-ci.com/\n"
+    expect(run_cli('endpoint', '--pro')).to be_success
+    expect(stdout).to eq("https://api.travis-ci.com/\n")
   end
 
   example "travis endpoint -e http://localhost:3000/" do
-    run_cli('endpoint', '-e', 'http://localhost:3000/').should be_success
-    stdout.should be == "http://localhost:3000/\n"
+    expect(run_cli('endpoint', '-e', 'http://localhost:3000/')).to be_success
+    expect(stdout).to eq("http://localhost:3000/\n")
   end
 
   example "TRAVIS_ENDPOINT=http://localhost:3000/ travis endpoint" do
     ENV['TRAVIS_ENDPOINT'] = "http://localhost:3000/"
-    run_cli('endpoint').should be_success
-    stdout.should be == "http://localhost:3000/\n"
+    expect(run_cli('endpoint')).to be_success
+    expect(stdout).to eq("http://localhost:3000/\n")
   end
 
   example "travis endpoint --github" do
-    run_cli('endpoint', '--github').should be_success
-    stdout.should be == "https://api.github.com\n"
+    expect(run_cli('endpoint', '--github')).to be_success
+    expect(stdout).to eq("https://api.github.com\n")
   end
 
   example "travis endpoint -i" do
-    run_cli('endpoint', '-i').should be_success
-    stdout.should be == "API endpoint: https://api.travis-ci.org/\n"
+    expect(run_cli('endpoint', '-i')).to be_success
+    expect(stdout).to eq("API endpoint: https://api.travis-ci.org/\n")
   end
 end

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -2,32 +2,32 @@ require 'spec_helper'
 
 describe Travis::CLI::Help do
   example "travis help" do
-    run_cli('help').should be_success
-    stdout.should include("Usage: travis COMMAND")
+    expect(run_cli('help')).to be_success
+    expect(stdout).to include("Usage: travis COMMAND")
   end
 
   example "travis --help" do
-    run_cli('--help').should be_success
-    stdout.should include("Usage: travis COMMAND")
+    expect(run_cli('--help')).to be_success
+    expect(stdout).to include("Usage: travis COMMAND")
   end
 
   example "travis -h" do
-    run_cli('-h').should be_success
-    stdout.should include("Usage: travis COMMAND")
+    expect(run_cli('-h')).to be_success
+    expect(stdout).to include("Usage: travis COMMAND")
   end
 
   example "travis -?" do
-    run_cli('-?').should be_success
-    stdout.should include("Usage: travis COMMAND")
+    expect(run_cli('-?')).to be_success
+    expect(stdout).to include("Usage: travis COMMAND")
   end
 
   example "travis help endpoint" do
-    run_cli('help', 'endpoint').should be_success
-    stdout.should include("Usage: travis endpoint [OPTIONS]")
+    expect(run_cli('help', 'endpoint')).to be_success
+    expect(stdout).to include("Usage: travis endpoint [OPTIONS]")
   end
 
   example "travis endpoint --help" do
-    run_cli('endpoint', '--help').should be_success
-    stdout.should include("Usage: travis endpoint [OPTIONS]")
+    expect(run_cli('endpoint', '--help')).to be_success
+    expect(stdout).to include("Usage: travis endpoint [OPTIONS]")
   end
 end

--- a/spec/cli/history_spec.rb
+++ b/spec/cli/history_spec.rb
@@ -2,37 +2,37 @@ require 'spec_helper'
 
 describe Travis::CLI::History do
   example 'travis history' do
-    run_cli('history').should be_success
-    stdout.should be == "#6180 failed:    master Associaton -> Association\n"
+    expect(run_cli('history')).to be_success
+    expect(stdout).to eq("#6180 failed:    master Associaton -> Association\n")
   end
 
   example 'travis history -d' do
-    run_cli('history', '-d').should be_success
-    stdout.should be =~ /2013-01-13 \d+:55:17 #6180 failed:    master Associaton -> Association/
+    expect(run_cli('history', '-d')).to be_success
+    expect(stdout).to match(/2013-01-13 \d+:55:17 #6180 failed:    master Associaton -> Association/)
   end
 
   example 'travis history -a 6180' do
-    run_cli('history', '-a', '6180').should be_success
-    stdout.should be == ''
+    expect(run_cli('history', '-a', '6180')).to be_success
+    expect(stdout).to eq('')
   end
 
   example 'travis history -b master' do
-    run_cli('history', '-b', 'master').should be_success
-    stdout.should be == "#6180 failed:    master Associaton -> Association\n"
+    expect(run_cli('history', '-b', 'master')).to be_success
+    expect(stdout).to eq("#6180 failed:    master Associaton -> Association\n")
   end
 
   example 'travis history -b not-master' do
-    run_cli('history', '-b', 'not-master').should be_success
-    stdout.should be_empty
+    expect(run_cli('history', '-b', 'not-master')).to be_success
+    expect(stdout).to be_empty
   end
 
   example 'travis history -p 5' do
-    run_cli('history', '-p', '5').should be_success
-    stdout.should be_empty
+    expect(run_cli('history', '-p', '5')).to be_success
+    expect(stdout).to be_empty
   end
 
   example 'travis history -c' do
-    run_cli('history', '-c').should be_success
-    stdout.should be == "#6180 failed:    master Steve Klabnik             Associaton -> Association\n"
+    expect(run_cli('history', '-c')).to be_success
+    expect(stdout).to eq("#6180 failed:    master Steve Klabnik             Associaton -> Association\n")
   end
 end

--- a/spec/cli/init_spec.rb
+++ b/spec/cli/init_spec.rb
@@ -15,31 +15,31 @@ describe Travis::CLI::Init do
   end
 
   example "travis init fakelanguage" do
-    run_cli('init', 'fakelanguage', '--skip-enable', '-r', 'travis-ci/travis.rb').should_not be_success
-    stderr.should be == "unknown language fakelanguage\n"
+    expect(run_cli('init', 'fakelanguage', '--skip-enable', '-r', 'travis-ci/travis.rb')).not_to be_success
+    expect(stderr).to eq("unknown language fakelanguage\n")
   end
 
   shared_examples_for 'travis init' do |language|
     example "travis init #{language} (empty directory)" do
-      File.exist?('.travis.yml').should be_false
-      run_cli('init', language, '--skip-enable', '-r', 'travis-ci/travis.rb').should be_success
-      stdout.should be == ".travis.yml file created!\n"
-      File.exist?('.travis.yml').should be_true
-      File.read('.travis.yml').should include("language: #{language}")
+      expect(File.exist?('.travis.yml')).to be_falsey
+      expect(run_cli('init', language, '--skip-enable', '-r', 'travis-ci/travis.rb')).to be_success
+      expect(stdout).to eq(".travis.yml file created!\n")
+      expect(File.exist?('.travis.yml')).to be_truthy
+      expect(File.read('.travis.yml')).to include("language: #{language}")
     end
 
     example "travis init #{language} (.travis.yml already exists, using --force)" do
       File.open(".travis.yml", "w") { |f| f << "old file" }
-      run_cli('init', language, '--force', '--skip-enable', '-r', 'travis-ci/travis.rb').should be_success
-      stdout.should be == ".travis.yml file created!\n"
-      File.read(".travis.yml").should_not be == "old file"
+      expect(run_cli('init', language, '--force', '--skip-enable', '-r', 'travis-ci/travis.rb')).to be_success
+      expect(stdout).to eq(".travis.yml file created!\n")
+      expect(File.read(".travis.yml")).not_to eq("old file")
     end
 
     example "travis init #{language} (.travis.yml already exists, not using --force)" do
       File.open(".travis.yml", "w") { |f| f << "old file" }
-      run_cli('init', language, '--skip-enable', '-r', 'travis-ci/travis.rb').should_not be_success
-      stderr.should be == ".travis.yml already exists, use --force to override\n"
-      File.read('.travis.yml').should be == "old file"
+      expect(run_cli('init', language, '--skip-enable', '-r', 'travis-ci/travis.rb')).not_to be_success
+      expect(stderr).to eq(".travis.yml already exists, use --force to override\n")
+      expect(File.read('.travis.yml')).to eq("old file")
     end
   end
 
@@ -52,9 +52,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('compiler')
-      result['compiler'].should include('clang')
-      result['compiler'].should include('gcc')
+      expect(result).to include('compiler')
+      expect(result['compiler']).to include('clang')
+      expect(result['compiler']).to include('gcc')
     end
   end
 
@@ -71,9 +71,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('compiler')
-      result['compiler'].should include('clang')
-      result['compiler'].should include('gcc')
+      expect(result).to include('compiler')
+      expect(result['compiler']).to include('clang')
+      expect(result['compiler']).to include('gcc')
     end
   end
 
@@ -86,8 +86,8 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('otp_release')
-      result['otp_release'].should include('R16B')
+      expect(result).to include('otp_release')
+      expect(result['otp_release']).to include('R16B')
     end
   end
 
@@ -100,9 +100,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('go')
-      result['go'].should include('1.0')
-      result['go'].should include('1.3')
+      expect(result).to include('go')
+      expect(result['go']).to include('1.0')
+      expect(result['go']).to include('1.3')
     end
   end
 
@@ -123,9 +123,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('jdk')
-      result['jdk'].should include('oraclejdk7')
-      result['jdk'].should include('openjdk6')
+      expect(result).to include('jdk')
+      expect(result['jdk']).to include('oraclejdk7')
+      expect(result['jdk']).to include('openjdk6')
     end
   end
 
@@ -138,9 +138,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('node_js')
-      result['node_js'].should include('0.11')
-      result['node_js'].should include('0.10')
+      expect(result).to include('node_js')
+      expect(result['node_js']).to include('0.11')
+      expect(result['node_js']).to include('0.10')
     end
   end
 
@@ -157,9 +157,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('perl')
-      result['perl'].should include('5.16')
-      result['perl'].should include('5.14')
+      expect(result).to include('perl')
+      expect(result['perl']).to include('5.16')
+      expect(result['perl']).to include('5.14')
     end
   end
 
@@ -172,9 +172,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('php')
-      result['php'].should include('5.5')
-      result['php'].should include('5.4')
+      expect(result).to include('php')
+      expect(result['php']).to include('5.5')
+      expect(result['php']).to include('5.4')
     end
   end
 
@@ -187,9 +187,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('python')
-      result['python'].should include('2.7')
-      result['python'].should include('3.3')
+      expect(result).to include('python')
+      expect(result['python']).to include('2.7')
+      expect(result['python']).to include('3.3')
     end
   end
 
@@ -202,10 +202,10 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('rvm')
-      result['rvm'].should     include('1.9.3')
-      result['rvm'].should     include('2.0.0')
-      result['rvm'].should_not include('1.8.7')
+      expect(result).to include('rvm')
+      expect(result['rvm']).to     include('1.9.3')
+      expect(result['rvm']).to     include('2.0.0')
+      expect(result['rvm']).not_to include('1.8.7')
     end
   end
 
@@ -218,9 +218,9 @@ describe Travis::CLI::Init do
     end
 
     it 'sets compiler' do
-      result.should include('scala')
-      result['scala'].should include('2.10.1')
-      result['scala'].should include('2.9.3')
+      expect(result).to include('scala')
+      expect(result['scala']).to include('2.10.1')
+      expect(result['scala']).to include('2.9.3')
     end
   end
 end

--- a/spec/cli/login_spec.rb
+++ b/spec/cli/login_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Travis::CLI::Login do
   example "travis login", :unless => Travis::Tools::System.windows? do
-    run_cli('login', '-E', '--skip-token-check') { |i| i.puts('rkh', 'password') }.should be_success
-    run_cli('whoami').out.should be == "rkh\n"
+    expect(run_cli('login', '-E', '--skip-token-check') { |i| i.puts('rkh', 'password') }).to be_success
+    expect(run_cli('whoami').out).to eq("rkh\n")
   end
 
   example "travis login (with bad credentials)", :unless => Travis::Tools::System.windows? do
-    run_cli('login') { |i| i.puts('rkh', 'wrong password') }.should_not be_success
-    run_cli('whoami').should_not be_success
+    expect(run_cli('login') { |i| i.puts('rkh', 'wrong password') }).not_to be_success
+    expect(run_cli('whoami')).not_to be_success
   end
 end

--- a/spec/cli/logs_spec.rb
+++ b/spec/cli/logs_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Travis::CLI::Logs do
   example 'logs 6180.1' do
-    run_cli('logs', '6180.1', '-E').should be_success
-    stdout.should be == "$ export GEM=railties\n"
+    expect(run_cli('logs', '6180.1', '-E')).to be_success
+    expect(stdout).to eq("$ export GEM=railties\n")
   end
 end

--- a/spec/cli/open_spec.rb
+++ b/spec/cli/open_spec.rb
@@ -2,32 +2,32 @@ require 'spec_helper'
 
 describe Travis::CLI::Open do
   example 'travis open -p' do
-    run_cli('open', '-p').should be_success
-    stdout.should match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb/)
+    expect(run_cli('open', '-p')).to be_success
+    expect(stdout).to match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb/)
   end
 
   example 'travis open 6180 -p' do
-    run_cli('open', '6180', '-p').should be_success
-    stdout.should match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb\/builds\/4125095/)
+    expect(run_cli('open', '6180', '-p')).to be_success
+    expect(stdout).to match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb\/builds\/4125095/)
   end
 
   example 'travis open 6180.1 -p' do
-    run_cli('open', '6180.1', '-p').should be_success
-    stdout.should match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb\/jobs\/4125096/)
+    expect(run_cli('open', '6180.1', '-p')).to be_success
+    expect(stdout).to match(/https:\/\/travis-ci.org\/[\w\W]*\/travis\.rb\/jobs\/4125096/)
   end
 
   example 'travis open -pg' do
-    run_cli('open', '-pg').should be_success
-    stdout.should match(/https:\/\/github.com\/[\w\W]*\/travis\.rb/)
+    expect(run_cli('open', '-pg')).to be_success
+    expect(stdout).to match(/https:\/\/github.com\/[\w\W]*\/travis\.rb/)
   end
 
   example 'travis open 6180 -pg' do
-    run_cli('open', '6180', '-pg').should be_success
-    stdout.should be == "https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c\n"
+    expect(run_cli('open', '6180', '-pg')).to be_success
+    expect(stdout).to eq("https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c\n")
   end
 
   example 'travis open 6180.1 -pg' do
-    run_cli('open', '6180.1', '-pg').should be_success
-    stdout.should be == "https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c\n"
+    expect(run_cli('open', '6180.1', '-pg')).to be_success
+    expect(stdout).to eq("https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c\n")
   end
 end

--- a/spec/cli/repo_command_spec.rb
+++ b/spec/cli/repo_command_spec.rb
@@ -5,17 +5,17 @@ describe Travis::CLI::RepoCommand do
   describe '#parse_remote' do
     it 'handles git@github.com URIs' do
       path = subject.send(:parse_remote, 'git@github.com:travis-ci/travis.rb.git')
-      path.should be == '/travis-ci/travis.rb.git'
+      expect(path).to eq('/travis-ci/travis.rb.git')
     end
 
     it 'handles GitHub Enterprise URIS' do
       path = subject.send(:parse_remote, 'git@example.com:travis-ci/travis.rb.git')
-      path.should be == '/travis-ci/travis.rb.git'
+      expect(path).to eq('/travis-ci/travis.rb.git')
     end
 
     it 'handles HTTPS URIs' do
       path = subject.send(:parse_remote, 'https://github.com/travis-ci/travis.rb.git')
-      path.should be == '/travis-ci/travis.rb.git'
+      expect(path).to eq('/travis-ci/travis.rb.git')
     end
 
     it 'raises URI::InvalidURIError for invalid URIs' do

--- a/spec/cli/restart_spec.rb
+++ b/spec/cli/restart_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Travis::CLI::Restart do
   example 'travis restart' do
-    run_cli('restart', '-t', 'token').should be_success
-    $params['build_id'].should be == "4125095"
-    $params['job_id'].should be_nil
+    expect(run_cli('restart', '-t', 'token')).to be_success
+    expect($params['build_id']).to eq("4125095")
+    expect($params['job_id']).to be_nil
   end
 
   example 'travis restart 6180.1' do
-    run_cli('restart', '6180.1', '-t', 'token').should be_success
-    $params['build_id'].should be_nil
-    $params['job_id'].should be == "4125096"
+    expect(run_cli('restart', '6180.1', '-t', 'token')).to be_success
+    expect($params['build_id']).to be_nil
+    expect($params['job_id']).to eq("4125096")
   end
 end

--- a/spec/cli/show_spec.rb
+++ b/spec/cli/show_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Travis::CLI::Show do
   example 'show 6180.1' do
-    run_cli('show', '6180.1', '-E').should be_success
-    stdout.should include("Config:        ")
-    stdout.should include("env: GEM=railties")
+    expect(run_cli('show', '6180.1', '-E')).to be_success
+    expect(stdout).to include("Config:        ")
+    expect(stdout).to include("env: GEM=railties")
   end
 end

--- a/spec/cli/status_spec.rb
+++ b/spec/cli/status_spec.rb
@@ -2,27 +2,27 @@ require 'spec_helper'
 
 describe Travis::CLI::Status do
   example "travis status" do
-    run_cli('status').should be_success
-    stdout.should be == "failed\n"
+    expect(run_cli('status')).to be_success
+    expect(stdout).to eq("failed\n")
   end
 
   example "travis status -x" do
-    run_cli('status', '-x').should_not be_success
-    stdout.should be == "failed\n"
+    expect(run_cli('status', '-x')).not_to be_success
+    expect(stdout).to eq("failed\n")
   end
 
   example "travis status -q" do
-    run_cli('status', '-q').should be_success
-    stdout.should be_empty
+    expect(run_cli('status', '-q')).to be_success
+    expect(stdout).to be_empty
   end
 
   example "travis status -pqx" do
-    run_cli('endpoint', '-pqx').should_not be_success
-    stdout.should be_empty
+    expect(run_cli('endpoint', '-pqx')).not_to be_success
+    expect(stdout).to be_empty
   end
 
   example "travis status -i" do
-    run_cli('status', '-i', '--skip-completion-check', '-r', 'travis-ci/travis.rb').should be_success
-    stdout.should be == "build #6180 failed\n"
+    expect(run_cli('status', '-i', '--skip-completion-check', '-r', 'travis-ci/travis.rb')).to be_success
+    expect(stdout).to eq("build #6180 failed\n")
   end
 end

--- a/spec/cli/token_spec.rb
+++ b/spec/cli/token_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe Travis::CLI::Token do
   example "travis token (access token set)" do
-    run_cli('token', '-t', 'super-secret').should be_success
-    stdout.should == "super-secret\n"
-    stderr.should be_empty
+    expect(run_cli('token', '-t', 'super-secret')).to be_success
+    expect(stdout).to eq("super-secret\n")
+    expect(stderr).to be_empty
   end
 
   example "travis token -i (access token set)" do
-    run_cli('token', '-it', 'super-secret').should be_success
-    stdout.should == "Your access token is super-secret\n"
-    stderr.should be_empty
+    expect(run_cli('token', '-it', 'super-secret')).to be_success
+    expect(stdout).to eq("Your access token is super-secret\n")
+    expect(stderr).to be_empty
   end
 
   example 'travis token (no access token set)' do
-    run_cli('token').should_not be_success
+    expect(run_cli('token')).not_to be_success
 
-    stdout.should be_empty
-    stderr.should == "not logged in, please run #{File.basename($0)} login\n"
+    expect(stdout).to be_empty
+    expect(stderr).to eq("not logged in, please run #{File.basename($0)} login\n")
   end
 end

--- a/spec/cli/version_spec.rb
+++ b/spec/cli/version_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe Travis::CLI::Version do
   example do
-    run_cli('-v').should be_success
-    stdout.should be == "#{Travis::VERSION}\n"
+    expect(run_cli('-v')).to be_success
+    expect(stdout).to eq("#{Travis::VERSION}\n")
   end
 
   example do
-    run_cli('--version').should be_success
-    stdout.should be == "#{Travis::VERSION}\n"
+    expect(run_cli('--version')).to be_success
+    expect(stdout).to eq("#{Travis::VERSION}\n")
   end
 
   example do
-    run_cli('version').should be_success
-    stdout.should be == "#{Travis::VERSION}\n"
+    expect(run_cli('version')).to be_success
+    expect(stdout).to eq("#{Travis::VERSION}\n")
   end
 end

--- a/spec/cli/whoami_spec.rb
+++ b/spec/cli/whoami_spec.rb
@@ -2,33 +2,33 @@ require 'spec_helper'
 
 describe Travis::CLI::Whoami do
   example "travis whoami" do
-    run_cli('whoami').should_not be_success
-    stdout.should be_empty
-    stderr.should be == "not logged in, please run #{File.basename $0} login\n"
+    expect(run_cli('whoami')).not_to be_success
+    expect(stdout).to be_empty
+    expect(stderr).to eq("not logged in, please run #{File.basename $0} login\n")
   end
 
   example "travis whoami --pro" do
-    run_cli('whoami', '--pro').should_not be_success
-    stdout.should be_empty
-    stderr.should be == "not logged in, please run #{File.basename $0} login --pro\n"
+    expect(run_cli('whoami', '--pro')).not_to be_success
+    expect(stdout).to be_empty
+    expect(stderr).to eq("not logged in, please run #{File.basename $0} login --pro\n")
   end
 
   example "travis whoami -t token" do
-    run_cli('whoami', '-t', 'token').should be_success
-    stdout.should be == "rkh\n"
-    stderr.should be_empty
+    expect(run_cli('whoami', '-t', 'token')).to be_success
+    expect(stdout).to eq("rkh\n")
+    expect(stderr).to be_empty
   end
 
   example "TRAVIS_TOKEN=token travis whoami" do
     ENV['TRAVIS_TOKEN'] = 'token'
-    run_cli('whoami').should be_success
-    stdout.should be == "rkh\n"
-    stderr.should be_empty
+    expect(run_cli('whoami')).to be_success
+    expect(stdout).to eq("rkh\n")
+    expect(stderr).to be_empty
   end
 
   example "travis whoami -t token -i" do
-    run_cli('whoami', '-t', 'token', '-i').should be_success
-    stdout.should be == "You are rkh (Konstantin Haase)\n"
-    stderr.should be_empty
+    expect(run_cli('whoami', '-t', 'token', '-i')).to be_success
+    expect(stdout).to eq("You are rkh (Konstantin Haase)\n")
+    expect(stderr).to be_empty
   end
 end

--- a/spec/client/account_spec.rb
+++ b/spec/client/account_spec.rb
@@ -4,29 +4,85 @@ describe Travis::Client::Account do
   context "from all accounts" do
     let(:session) { Travis::Client.new }
     subject { session.accounts.first }
-    its(:name) { should be == 'Konstantin Haase' }
-    its(:login) { should be == 'rkh' }
-    its(:type) { should be == 'user' }
-    its(:repos_count) { should be == 200 }
-    its(:inspect) { should be == "#<Travis::Client::Account: rkh>" }
+
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to eq('Konstantin Haase') }
+    end
+
+    describe '#login' do
+      subject { super().login }
+      it { is_expected.to eq('rkh') }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it { is_expected.to eq('user') }
+    end
+
+    describe '#repos_count' do
+      subject { super().repos_count }
+      it { is_expected.to eq(200) }
+    end
+
+    describe '#inspect' do
+      subject { super().inspect }
+      it { is_expected.to eq("#<Travis::Client::Account: rkh>") }
+    end
   end
 
   context "known account" do
     let(:session) { Travis::Client.new }
     subject { session.account('rkh') }
-    its(:name) { should be == 'Konstantin Haase' }
-    its(:login) { should be == 'rkh' }
-    its(:type) { should be == 'user' }
-    its(:repos_count) { should be == 200 }
-    its(:inspect) { should be == "#<Travis::Client::Account: rkh>" }
+
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to eq('Konstantin Haase') }
+    end
+
+    describe '#login' do
+      subject { super().login }
+      it { is_expected.to eq('rkh') }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it { is_expected.to eq('user') }
+    end
+
+    describe '#repos_count' do
+      subject { super().repos_count }
+      it { is_expected.to eq(200) }
+    end
+
+    describe '#inspect' do
+      subject { super().inspect }
+      it { is_expected.to eq("#<Travis::Client::Account: rkh>") }
+    end
   end
 
   context "known account" do
     let(:session) { Travis::Client.new }
     subject { session.account('foo') }
-    its(:name) { should be_nil }
-    its(:login) { should be == 'foo' }
-    its(:type) { should be_nil }
-    its(:inspect) { should be == "#<Travis::Client::Account: foo>" }
+
+    describe '#name' do
+      subject { super().name }
+      it { is_expected.to be_nil }
+    end
+
+    describe '#login' do
+      subject { super().login }
+      it { is_expected.to eq('foo') }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it { is_expected.to be_nil }
+    end
+
+    describe '#inspect' do
+      subject { super().inspect }
+      it { is_expected.to eq("#<Travis::Client::Account: foo>") }
+    end
   end
 end

--- a/spec/client/annotation_spec.rb
+++ b/spec/client/annotation_spec.rb
@@ -4,11 +4,31 @@ describe Travis::Client::Annotation do
   let(:session) { Travis::Client.new }
   let(:job) { session.job(4125097) }
   subject { job.annotations.first }
-  its(:id) { should be == 1 }
-  its(:description) { should be == "The job passed." }
-  its(:provider_name) { should be == "Travis CI" }
-  its(:url) { should be == "https://travis-ci.org/rails/rails/jobs/4125097" }
-  its(:status) { should be == '' }
 
-  it { should be == subject.job.annotations.first }
+  describe '#id' do
+    subject { super().id }
+    it { is_expected.to eq(1) }
+  end
+
+  describe '#description' do
+    subject { super().description }
+    it { is_expected.to eq("The job passed.") }
+  end
+
+  describe '#provider_name' do
+    subject { super().provider_name }
+    it { is_expected.to eq("Travis CI") }
+  end
+
+  describe '#url' do
+    subject { super().url }
+    it { is_expected.to eq("https://travis-ci.org/rails/rails/jobs/4125097") }
+  end
+
+  describe '#status' do
+    subject { super().status }
+    it { is_expected.to eq('') }
+  end
+
+  it { is_expected.to eq(subject.job.annotations.first) }
 end

--- a/spec/client/broadcast_spec.rb
+++ b/spec/client/broadcast_spec.rb
@@ -4,7 +4,14 @@ describe Travis::Client::Broadcast do
   let(:session) { Travis::Client.new }
   subject { session.broadcasts.first }
 
-  its(:id) { should be == 1 }
-  its(:message) { should be == "Hello!" }
+  describe '#id' do
+    subject { super().id }
+    it { is_expected.to eq(1) }
+  end
+
+  describe '#message' do
+    subject { super().message }
+    it { is_expected.to eq("Hello!") }
+  end
 
 end

--- a/spec/client/build_spec.rb
+++ b/spec/client/build_spec.rb
@@ -3,29 +3,69 @@ require 'spec_helper'
 describe Travis::Client::Build do
   let(:session) { Travis::Client.new }
   subject { session.build(4125095) }
-  its(:number) { should be == '6180' }
-  its(:state) { should be == 'failed' }
-  its(:duration) { should be == 5019 }
-  its(:started_at) { should be_a(Time) }
-  its(:finished_at) { should be_nil }
-  its(:inspect) { should be == "#<Travis::Client::Build: rails/rails#6180>" }
-  its(:color) { should be == 'red' }
-  its(:commit) { should be_a(Travis::Client::Commit) }
-  its(:jobs) { should be_an(Array) }
-  its(:repository) { should be == session.repo('rails/rails') }
 
-  it { should be == subject.repository.last_build }
+  describe '#number' do
+    subject { super().number }
+    it { is_expected.to eq('6180') }
+  end
 
-  it { should_not be_pending  }
-  it { should     be_started  }
-  it { should     be_finished }
-  it { should_not be_passed   }
-  it { should_not be_errored  }
-  it { should     be_failed   }
-  it { should_not be_canceled }
-  it { should     be_created  }
-  it { should     be_red      }
-  it { should_not be_green    }
-  it { should_not be_yellow   }
-  it { should be_unsuccessful }
+  describe '#state' do
+    subject { super().state }
+    it { is_expected.to eq('failed') }
+  end
+
+  describe '#duration' do
+    subject { super().duration }
+    it { is_expected.to eq(5019) }
+  end
+
+  describe '#started_at' do
+    subject { super().started_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  describe '#finished_at' do
+    subject { super().finished_at }
+    it { is_expected.to be_nil }
+  end
+
+  describe '#inspect' do
+    subject { super().inspect }
+    it { is_expected.to eq("#<Travis::Client::Build: rails/rails#6180>") }
+  end
+
+  describe '#color' do
+    subject { super().color }
+    it { is_expected.to eq('red') }
+  end
+
+  describe '#commit' do
+    subject { super().commit }
+    it { is_expected.to be_a(Travis::Client::Commit) }
+  end
+
+  describe '#jobs' do
+    subject { super().jobs }
+    it { is_expected.to be_an(Array) }
+  end
+
+  describe '#repository' do
+    subject { super().repository }
+    it { is_expected.to eq(session.repo('rails/rails')) }
+  end
+
+  it { is_expected.to eq(subject.repository.last_build) }
+
+  it { is_expected.not_to be_pending  }
+  it { is_expected.to     be_started  }
+  it { is_expected.to     be_finished }
+  it { is_expected.not_to be_passed   }
+  it { is_expected.not_to be_errored  }
+  it { is_expected.to     be_failed   }
+  it { is_expected.not_to be_canceled }
+  it { is_expected.to     be_created  }
+  it { is_expected.to     be_red      }
+  it { is_expected.not_to be_green    }
+  it { is_expected.not_to be_yellow   }
+  it { is_expected.to be_unsuccessful }
 end

--- a/spec/client/commit_spec.rb
+++ b/spec/client/commit_spec.rb
@@ -4,19 +4,62 @@ describe Travis::Client::Build do
   let(:session) { Travis::Client.new }
   subject { session.build(4125095).commit }
 
-  its(:sha) { should be == 'a0265b98f16c6e33be32aa3f57231d1189302400' }
-  its(:short_sha) { should be == 'a0265b9' }
-  its(:branch) { should be == 'master' }
-  its(:message) { should be == 'Associaton -> Association' }
-  its(:committed_at) { should be_a(Time) }
-  its(:author_name) { should be == 'Steve Klabnik' }
-  its(:author_email) { should be == 'steve@steveklabnik.com' }
-  its(:committer_name) { should be == 'Steve Klabnik' }
-  its(:committer_email) { should be == 'steve@steveklabnik.com' }
-  its(:compare_url) { should be == 'https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c' }
-  its(:subject) { should be == 'Associaton -> Association' }
+  describe '#sha' do
+    subject { super().sha }
+    it { is_expected.to eq('a0265b98f16c6e33be32aa3f57231d1189302400') }
+  end
+
+  describe '#short_sha' do
+    subject { super().short_sha }
+    it { is_expected.to eq('a0265b9') }
+  end
+
+  describe '#branch' do
+    subject { super().branch }
+    it { is_expected.to eq('master') }
+  end
+
+  describe '#message' do
+    subject { super().message }
+    it { is_expected.to eq('Associaton -> Association') }
+  end
+
+  describe '#committed_at' do
+    subject { super().committed_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  describe '#author_name' do
+    subject { super().author_name }
+    it { is_expected.to eq('Steve Klabnik') }
+  end
+
+  describe '#author_email' do
+    subject { super().author_email }
+    it { is_expected.to eq('steve@steveklabnik.com') }
+  end
+
+  describe '#committer_name' do
+    subject { super().committer_name }
+    it { is_expected.to eq('Steve Klabnik') }
+  end
+
+  describe '#committer_email' do
+    subject { super().committer_email }
+    it { is_expected.to eq('steve@steveklabnik.com') }
+  end
+
+  describe '#compare_url' do
+    subject { super().compare_url }
+    it { is_expected.to eq('https://github.com/rails/rails/compare/6581d798e830...a0265b98f16c') }
+  end
+
+  describe '#subject' do
+    subject { super().subject }
+    it { is_expected.to eq('Associaton -> Association') }
+  end
 
   specify "with missing data" do
-    session.load("commit" => { "id" => 12 })['commit'].subject.should be_empty
+    expect(session.load("commit" => { "id" => 12 })['commit'].subject).to be_empty
   end
 end

--- a/spec/client/job_spec.rb
+++ b/spec/client/job_spec.rb
@@ -3,28 +3,64 @@ require 'spec_helper'
 describe Travis::Client::Job do
   let(:session) { Travis::Client.new }
   subject { session.job(4125097) }
-  its(:number) { should be == '6180.2' }
-  its(:state) { should be == 'passed' }
-  its(:started_at) { should be_a(Time) }
-  its(:finished_at) { should be_a(Time) }
-  its(:inspect) { should be == "#<Travis::Client::Job: rails/rails#6180.2>" }
-  its(:color) { should be == 'green' }
-  its(:commit) { should be_a(Travis::Client::Commit) }
-  its(:repository) { should be == session.repo('rails/rails') }
-  its(:duration) { should be == 905 }
 
-  it { should be == subject.build.jobs[1] }
+  describe '#number' do
+    subject { super().number }
+    it { is_expected.to eq('6180.2') }
+  end
 
-  it { should_not be_pending      }
-  it { should     be_started      }
-  it { should     be_finished     }
-  it { should     be_passed       }
-  it { should_not be_errored      }
-  it { should_not be_failed       }
-  it { should_not be_canceled     }
-  it { should     be_created      }
-  it { should_not be_red          }
-  it { should     be_green        }
-  it { should_not be_yellow       }
-  it { should_not be_unsuccessful }
+  describe '#state' do
+    subject { super().state }
+    it { is_expected.to eq('passed') }
+  end
+
+  describe '#started_at' do
+    subject { super().started_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  describe '#finished_at' do
+    subject { super().finished_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  describe '#inspect' do
+    subject { super().inspect }
+    it { is_expected.to eq("#<Travis::Client::Job: rails/rails#6180.2>") }
+  end
+
+  describe '#color' do
+    subject { super().color }
+    it { is_expected.to eq('green') }
+  end
+
+  describe '#commit' do
+    subject { super().commit }
+    it { is_expected.to be_a(Travis::Client::Commit) }
+  end
+
+  describe '#repository' do
+    subject { super().repository }
+    it { is_expected.to eq(session.repo('rails/rails')) }
+  end
+
+  describe '#duration' do
+    subject { super().duration }
+    it { is_expected.to eq(905) }
+  end
+
+  it { is_expected.to eq(subject.build.jobs[1]) }
+
+  it { is_expected.not_to be_pending      }
+  it { is_expected.to     be_started      }
+  it { is_expected.to     be_finished     }
+  it { is_expected.to     be_passed       }
+  it { is_expected.not_to be_errored      }
+  it { is_expected.not_to be_failed       }
+  it { is_expected.not_to be_canceled     }
+  it { is_expected.to     be_created      }
+  it { is_expected.not_to be_red          }
+  it { is_expected.to     be_green        }
+  it { is_expected.not_to be_yellow       }
+  it { is_expected.not_to be_unsuccessful }
 end

--- a/spec/client/methods_spec.rb
+++ b/spec/client/methods_spec.rb
@@ -5,11 +5,22 @@ describe Travis::Client::Methods do
   subject { OpenStruct.new(:session => session).extend(Travis::Client::Methods) }
   before { subject.access_token = 'token' }
 
-  its(:api_endpoint) { should be == 'https://api.travis-ci.org/' }
-  its(:repos) { should be == session.find_many(Travis::Client::Repository) }
-  its(:user) { should be == session.find_one(Travis::Client::User) }
+  describe '#api_endpoint' do
+    subject { super().api_endpoint }
+    it { is_expected.to eq('https://api.travis-ci.org/') }
+  end
+
+  describe '#repos' do
+    subject { super().repos }
+    it { is_expected.to eq(session.find_many(Travis::Client::Repository)) }
+  end
+
+  describe '#user' do
+    subject { super().user }
+    it { is_expected.to eq(session.find_one(Travis::Client::User)) }
+  end
 
   it 'fetches a single repo' do
-    subject.repo(891).slug.should be == 'rails/rails'
+    expect(subject.repo(891).slug).to eq('rails/rails')
   end
 end

--- a/spec/client/methods_spec.rb
+++ b/spec/client/methods_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Travis::Client::Methods do
   let(:session) { Travis::Client.new }
   subject { OpenStruct.new(:session => session).extend(Travis::Client::Methods) }
-  before { subject.access_token = 'token' }
+  before(:each) { session.access_token = "token" }
 
   describe '#api_endpoint' do
     subject { super().api_endpoint }

--- a/spec/client/namespace_spec.rb
+++ b/spec/client/namespace_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 describe Travis::Client::Namespace do
-  it { should be_a(Travis::Client::Methods) }
+  it { is_expected.to be_a(Travis::Client::Methods) }
 
   it 'creates a dummy for repos' do
     repo = subject::Repository
-    repo.find_one('rails/rails').should be_a(Travis::Client::Repository)
-    repo.find_many.should be_an(Array)
-    repo.current.should be == repo.find_many
+    expect(repo.find_one('rails/rails')).to be_a(Travis::Client::Repository)
+    expect(repo.find_many).to be_an(Array)
+    expect(repo.current).to eq(repo.find_many)
   end
 
   it 'creates a dummy for user' do
     subject.access_token = 'token'
     user = subject::User
-    user.find_one.should be_a(Travis::Client::User)
-    user.current.should be == user.find_one
+    expect(user.find_one).to be_a(Travis::Client::User)
+    expect(user.current).to eq(user.find_one)
   end
 end

--- a/spec/client/repository_spec.rb
+++ b/spec/client/repository_spec.rb
@@ -4,36 +4,95 @@ describe Travis::Client::Repository do
   let(:session) { Travis::Client.new }
   subject { session.repo('rails/rails') }
 
-  its(:slug) { should be == 'rails/rails' }
-  its(:description) { should_not be_empty }
-  its(:last_build_id) { should be == 4125095 }
-  its(:last_build_number) { should be == '6180' }
-  its(:last_build_state) { should be == 'failed' }
-  its(:last_build_duration) { should be == 5019 }
-  its(:last_build_started_at) { should be_a(Time) }
-  its(:last_build_finished_at) { should be_nil }
-  its(:inspect) { should be == "#<Travis::Client::Repository: rails/rails>" }
-  its(:key) { should be_a(Travis::Client::Repository::Key) }
-  its(:last_build) { should be_a(Travis::Client::Build) }
-  its(:color) { should be == 'red' }
-  its(:github_language) { should be == 'Ruby' }
-  its(:owner_name) { should be == 'rails' }
-  its(:owner) { should be == session.account("rails") }
+  describe '#slug' do
+    subject { super().slug }
+    it { is_expected.to eq('rails/rails') }
+  end
 
-  it { should_not be_pending  }
-  it { should     be_started  }
-  it { should     be_finished }
-  it { should_not be_passed   }
-  it { should_not be_errored  }
-  it { should     be_failed   }
-  it { should_not be_canceled }
-  it { should     be_created  }
-  it { should     be_red      }
-  it { should_not be_green    }
-  it { should_not be_yellow   }
-  it { should be_unsuccessful }
+  describe '#description' do
+    subject { super().description }
+    it { is_expected.not_to be_empty }
+  end
+
+  describe '#last_build_id' do
+    subject { super().last_build_id }
+    it { is_expected.to eq(4125095) }
+  end
+
+  describe '#last_build_number' do
+    subject { super().last_build_number }
+    it { is_expected.to eq('6180') }
+  end
+
+  describe '#last_build_state' do
+    subject { super().last_build_state }
+    it { is_expected.to eq('failed') }
+  end
+
+  describe '#last_build_duration' do
+    subject { super().last_build_duration }
+    it { is_expected.to eq(5019) }
+  end
+
+  describe '#last_build_started_at' do
+    subject { super().last_build_started_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  describe '#last_build_finished_at' do
+    subject { super().last_build_finished_at }
+    it { is_expected.to be_nil }
+  end
+
+  describe '#inspect' do
+    subject { super().inspect }
+    it { is_expected.to eq("#<Travis::Client::Repository: rails/rails>") }
+  end
+
+  describe '#key' do
+    subject { super().key }
+    it { is_expected.to be_a(Travis::Client::Repository::Key) }
+  end
+
+  describe '#last_build' do
+    subject { super().last_build }
+    it { is_expected.to be_a(Travis::Client::Build) }
+  end
+
+  describe '#color' do
+    subject { super().color }
+    it { is_expected.to eq('red') }
+  end
+
+  describe '#github_language' do
+    subject { super().github_language }
+    it { is_expected.to eq('Ruby') }
+  end
+
+  describe '#owner_name' do
+    subject { super().owner_name }
+    it { is_expected.to eq('rails') }
+  end
+
+  describe '#owner' do
+    subject { super().owner }
+    it { is_expected.to eq(session.account("rails")) }
+  end
+
+  it { is_expected.not_to be_pending  }
+  it { is_expected.to     be_started  }
+  it { is_expected.to     be_finished }
+  it { is_expected.not_to be_passed   }
+  it { is_expected.not_to be_errored  }
+  it { is_expected.to     be_failed   }
+  it { is_expected.not_to be_canceled }
+  it { is_expected.to     be_created  }
+  it { is_expected.to     be_red      }
+  it { is_expected.not_to be_green    }
+  it { is_expected.not_to be_yellow   }
+  it { is_expected.to be_unsuccessful }
 
   it 'should expose the pubkey fingerprint' do
-    subject.public_key.fingerprint.should be == 'foobar'
+    expect(subject.public_key.fingerprint).to eq('foobar')
   end
 end

--- a/spec/client/session_spec.rb
+++ b/spec/client/session_spec.rb
@@ -1,26 +1,32 @@
 require 'spec_helper'
 
 describe Travis::Client::Session do
-  it { should be_a(Travis::Client::Methods) }
+  it { is_expected.to be_a(Travis::Client::Methods) }
 
   describe "uri" do
-    its(:uri) { should be == "https://api.travis-ci.org/" }
+    describe '#uri' do
+      subject { super().uri }
+      it { is_expected.to eq("https://api.travis-ci.org/") }
+    end
 
     it 'can be set as argument' do
-      Travis::Client::Session.new('http://foo/').uri.should be == 'http://foo/'
+      expect(Travis::Client::Session.new('http://foo/').uri).to eq('http://foo/')
     end
 
     it 'can be set as hash argument' do
-      Travis::Client::Session.new(:uri => 'http://foo/').uri.should be == 'http://foo/'
+      expect(Travis::Client::Session.new(:uri => 'http://foo/').uri).to eq('http://foo/')
     end
   end
 
   describe "access_token" do
-    its(:access_token) { should be_nil }
+    describe '#access_token' do
+      subject { super().access_token }
+      it { is_expected.to be_nil }
+    end
 
     it 'gives authenticated access if set' do
       subject.access_token = 'token'
-      subject.user.login.should be == 'rkh'
+      expect(subject.user.login).to eq('rkh')
     end
 
     it 'raises if token is not set' do
@@ -29,74 +35,77 @@ describe Travis::Client::Session do
   end
 
   describe "connection" do
-    its(:connection) { should be_a(Faraday::Connection) }
+    describe '#connection' do
+      subject { super().connection }
+      it { is_expected.to be_a(Faraday::Connection) }
+    end
 
     it 'creates a new connection when changing the uri' do
       old_connection = subject.connection
       subject.uri    = 'http://localhost:3000'
-      subject.connection.should_not be == old_connection
+      expect(subject.connection).not_to eq(old_connection)
     end
   end
 
   describe "headers" do
     it 'propagates headers to connection headers' do
       subject.headers['foo'] = 'bar'
-      subject.connection.headers.should include('foo')
+      expect(subject.connection.headers).to include('foo')
     end
 
     it 'propagates headers to new connections' do
       subject.headers['foo'] = 'bar'
       subject.connection = Faraday::Connection.new
-      subject.connection.headers.should include('foo')
+      expect(subject.connection.headers).to include('foo')
     end
 
     it 'is possible to set headers as constructor option' do
-      Travis::Client::Session.new(:headers => {'foo' => 'bar'}, :uri => 'http://localhost:3000/').
-        connection.headers['foo'].should be == 'bar'
+      expect(Travis::Client::Session.new(:headers => {'foo' => 'bar'}, :uri => 'http://localhost:3000/').
+        connection.headers['foo']).to eq('bar')
     end
 
     it 'sets a User-Agent' do
-      subject.headers['User-Agent'].should include("Travis/#{Travis::VERSION}")
-      subject.headers['User-Agent'].should include("Faraday/#{Faraday::VERSION}")
-      subject.headers['User-Agent'].should include("Rack/#{Rack.version}")
-      subject.headers['User-Agent'].should include("Ruby #{RUBY_VERSION}")
+      expect(subject.headers['User-Agent']).to include("Travis/#{Travis::VERSION}")
+      expect(subject.headers['User-Agent']).to include("Faraday/#{Faraday::VERSION}")
+      expect(subject.headers['User-Agent']).to include("Rack/#{Rack.version}")
+      expect(subject.headers['User-Agent']).to include("Ruby #{RUBY_VERSION}")
     end
 
     it 'allows adding custom infos to the User-Agent' do
       subject.agent_info = "foo"
-      subject.headers['User-Agent'].should include("foo")
-      subject.headers['User-Agent'].should include("Travis/#{Travis::VERSION}")
-      subject.headers['User-Agent'].should include("Faraday/#{Faraday::VERSION}")
-      subject.headers['User-Agent'].should include("Rack/#{Rack.version}")
-      subject.headers['User-Agent'].should include("Ruby #{RUBY_VERSION}")
+      expect(subject.headers['User-Agent']).to include("foo")
+      expect(subject.headers['User-Agent']).to include("Travis/#{Travis::VERSION}")
+      expect(subject.headers['User-Agent']).to include("Faraday/#{Faraday::VERSION}")
+      expect(subject.headers['User-Agent']).to include("Rack/#{Rack.version}")
+      expect(subject.headers['User-Agent']).to include("Ruby #{RUBY_VERSION}")
     end
   end
 
   describe "find_one" do
     it 'finds one instance' do
       repo = subject.find_one(Travis::Client::Repository, 'rails/rails')
-      repo.should be_a(Travis::Client::Repository)
-      repo.slug.should be == 'rails/rails'
+      expect(repo).to be_a(Travis::Client::Repository)
+      expect(repo.slug).to eq('rails/rails')
     end
   end
 
   describe "find_many" do
     it 'finds many instances' do
       repos = subject.find_many(Travis::Client::Repository)
-      repos.should be_an(Array)
-      repos.each { |repo| repo.should be_a(Travis::Client::Repository) }
-      repos.first.slug.should be == "pypug/django-mango"
+      expect(repos).to be_an(Array)
+      repos.each { |repo| expect(repo).to be_a(Travis::Client::Repository) }
+      expect(repos.first.slug).to eq("pypug/django-mango")
     end
   end
 
   describe "find_one_or_many" do
     it 'finds one instance' do
       subject.access_token = 'token'
-      subject.find_one_or_many(Travis::Client::User).should be_a(Travis::Client::User)
+      expect(subject.find_one_or_many(Travis::Client::User)).to be_a(Travis::Client::User)
     end
 
     it 'finds many instances' do
-      subject.find_one_or_many(Travis::Client::Repository).should be_an(Array)
+      expect(subject.find_one_or_many(Travis::Client::Repository)).to be_an(Array)
     end
   end
 
@@ -104,18 +113,18 @@ describe Travis::Client::Session do
     it 'reloads an instance' do
       Travis::Client::Session::FakeAPI.rails_description = "Ruby on Rails"
       rails = subject.find_one(Travis::Client::Repository, 'rails/rails')
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       Travis::Client::Session::FakeAPI.rails_description = 'Rails on the Rubies'
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       subject.reload(rails)
-      rails.description.should be == 'Rails on the Rubies'
+      expect(rails.description).to eq('Rails on the Rubies')
     end
   end
 
   describe "get" do
     it 'fetches a payload and substitutes values with entities' do
       result = subject.get('/repos/')
-      result['repos'].first.slug.should be == "pypug/django-mango"
+      expect(result['repos'].first.slug).to eq("pypug/django-mango")
     end
   end
 
@@ -123,17 +132,17 @@ describe Travis::Client::Session do
     it 'resets all the entities' do
       Travis::Client::Session::FakeAPI.rails_description = "Ruby on Rails"
       rails = subject.find_one(Travis::Client::Repository, 'rails/rails')
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       Travis::Client::Session::FakeAPI.rails_description = 'Rails on the Rubies'
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       subject.clear_cache
-      rails.description.should be == 'Rails on the Rubies'
+      expect(rails.description).to eq('Rails on the Rubies')
     end
 
     it 'keeps entries in the identity map' do
       rails = subject.repo('rails/rails')
       subject.clear_cache
-      subject.repo('rails/rails').should be_equal(rails)
+      expect(subject.repo('rails/rails')).to be_equal(rails)
     end
   end
 
@@ -141,25 +150,31 @@ describe Travis::Client::Session do
     it 'resets all the entities' do
       Travis::Client::Session::FakeAPI.rails_description = "Ruby on Rails"
       rails = subject.find_one(Travis::Client::Repository, 'rails/rails')
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       Travis::Client::Session::FakeAPI.rails_description = 'Rails on the Rubies'
-      rails.description.should be == 'Ruby on Rails'
+      expect(rails.description).to eq('Ruby on Rails')
       subject.clear_cache!
-      rails.description.should be == 'Rails on the Rubies'
+      expect(rails.description).to eq('Rails on the Rubies')
     end
 
     it 'does not keep entries in the identity map' do
       rails = subject.repo('rails/rails')
       subject.clear_cache!
-      subject.repo('rails/rails').should_not be_equal(rails)
+      expect(subject.repo('rails/rails')).not_to be_equal(rails)
     end
   end
 
   describe "session" do
-    its(:session) { should eq(subject) }
+    describe '#session' do
+      subject { super().session }
+      it { is_expected.to eq(subject) }
+    end
   end
 
   describe "config" do
-    its(:config) { should be == {"host" => "travis-ci.org"}}
+    describe '#config' do
+      subject { super().config }
+      it { is_expected.to eq({"host" => "travis-ci.org"})}
+    end
   end
 end

--- a/spec/client/user_spec.rb
+++ b/spec/client/user_spec.rb
@@ -3,14 +3,42 @@ require 'spec_helper'
 describe Travis::Client::User do
   # attributes :login, :name, :email, :gravatar_id, :locale, :is_syncing, :synced_at, :correct_scopes
   subject { Travis::Client.new(:access_token => 'token').user }
-  its(:login) { should be == 'rkh' }
-  its(:name) { should be == 'Konstantin Haase' }
-  its(:email) { should be == 'konstantin.haase@gmail.com' }
-  its(:gravatar_id) { should be == '5c2b452f6eea4a6d84c105ebd971d2a4' }
-  its(:locale) { should be == 'en' }
-  its(:is_syncing) { should be_false }
-  its(:synced_at) { should be_a(Time) }
 
-  it { should_not be_syncing }
-  it { should be_correct_scopes }
+  describe '#login' do
+    subject { super().login }
+    it { is_expected.to eq('rkh') }
+  end
+
+  describe '#name' do
+    subject { super().name }
+    it { is_expected.to eq('Konstantin Haase') }
+  end
+
+  describe '#email' do
+    subject { super().email }
+    it { is_expected.to eq('konstantin.haase@gmail.com') }
+  end
+
+  describe '#gravatar_id' do
+    subject { super().gravatar_id }
+    it { is_expected.to eq('5c2b452f6eea4a6d84c105ebd971d2a4') }
+  end
+
+  describe '#locale' do
+    subject { super().locale }
+    it { is_expected.to eq('en') }
+  end
+
+  describe '#is_syncing' do
+    subject { super().is_syncing }
+    it { is_expected.to be_falsey }
+  end
+
+  describe '#synced_at' do
+    subject { super().synced_at }
+    it { is_expected.to be_a(Time) }
+  end
+
+  it { is_expected.not_to be_syncing }
+  it { is_expected.to be_correct_scopes }
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe Travis::Client do
-  its(:new) { should be_a(Travis::Client::Session) }
+  describe '#new' do
+    subject { super().new }
+    it { is_expected.to be_a(Travis::Client::Session) }
+  end
 
   it 'accepts string argument' do
-    Travis::Client.new('http://foo/').uri.should be == 'http://foo/'
+    expect(Travis::Client.new('http://foo/').uri).to eq('http://foo/')
   end
 
   it 'accepts options hash with string keys' do
-    Travis::Client.new('uri' => 'http://foo/').uri.should be == 'http://foo/'
+    expect(Travis::Client.new('uri' => 'http://foo/').uri).to eq('http://foo/')
   end
 
   it 'accepts options hash with symbol keys' do
-    Travis::Client.new(:uri => 'http://foo/').uri.should be == 'http://foo/'
+    expect(Travis::Client.new(:uri => 'http://foo/').uri).to eq('http://foo/')
   end
 end

--- a/spec/pro_spec.rb
+++ b/spec/pro_spec.rb
@@ -1,10 +1,14 @@
 require 'spec_helper'
 
 describe Travis::Pro do
-  it { should be_a(Travis::Client::Namespace) }
-  its(:api_endpoint) { should be == 'https://api.travis-ci.com/' }
+  it { is_expected.to be_a(Travis::Client::Namespace) }
+
+  describe '#api_endpoint' do
+    subject { super().api_endpoint }
+    it { is_expected.to eq('https://api.travis-ci.com/') }
+  end
 
   it 'has a nice inspect on entities' do
-    Travis::Pro::Repository.find('rails/rails').inspect.should be == "#<Travis::Pro::Repository: rails/rails>"
+    expect(Travis::Pro::Repository.find('rails/rails').inspect).to eq("#<Travis::Pro::Repository: rails/rails>")
   end
 end

--- a/spec/travis_spec.rb
+++ b/spec/travis_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 
 describe Travis do
-  its(:api_endpoint) { should be == 'https://api.travis-ci.org/' }
+  describe '#api_endpoint' do
+    subject { super().api_endpoint }
+    it { is_expected.to eq('https://api.travis-ci.org/') }
+  end
 
   it 'has a nice inspect on entities' do
-    pending "does not work on JRuby" if defined? RUBY_ENGINE and RUBY_ENGINE == 'jruby'
-    Travis::Repository.find('rails/rails').inspect.should be == "#<Travis::Repository: rails/rails>"
+    skip "does not work on JRuby" if defined? RUBY_ENGINE and RUBY_ENGINE == 'jruby'
+    expect(Travis::Repository.find('rails/rails').inspect).to eq("#<Travis::Repository: rails/rails>")
   end
 end

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -300,7 +300,7 @@ Gem::Specification.new do |s|
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
-  s.add_development_dependency "rspec",     "~> 2.12"
+  s.add_development_dependency "rspec",     "~> 2.99"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"
 

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -300,7 +300,7 @@ Gem::Specification.new do |s|
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "pusher-client",         "~> 0.4"
-  s.add_development_dependency "rspec",     "~> 2.99"
+  s.add_development_dependency "rspec",     "~> 3.4"
   s.add_development_dependency "sinatra",   "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"
 


### PR DESCRIPTION
Use the method documented [here](http://rspec.info/upgrading-from-rspec-2/) to upgrade from rspec 2 to rspec 3. This cleans up all of the deprecation warnings from the specs.
