### PR TITLE
Disable line wrap.

### DIFF
--- a/lib/travis/cli/repo_command.rb
+++ b/lib/travis/cli/repo_command.rb
@@ -144,7 +144,7 @@ module Travis
         end
 
         def save_travis_config(file = travis_yaml)
-          yaml = travis_config.to_yaml
+          yaml = travis_config.to_yaml(line_width: -1)
           yaml.gsub! /^(\s+)('on'|true):/, "\\1on:"
           yaml.gsub! /\A---\s*\n/, ''
           File.write(file, yaml)


### PR DESCRIPTION
The Psych [line wrap](http://stackoverflow.com/questions/17859864/why-does-psych-yaml-interpreter-add-line-breaks-around-80-characters) is a little problematic. Not sure if this a common issue for users here, but at least [this validator](http://codebeautify.org/yaml-validator) barfs on `.travis.yml` output from `encrypt-file --add`.
