### PR TITLE
rake appears to require 1.9.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 1.9.2
 - 1.9.3
 - 2.0.0
 - 2.1.0


### PR DESCRIPTION
My previous PR #388 fails on 1.9.2 CI build with the following error:

```
Gem::InstallError: rake requires Ruby version >= 1.9.3.
```

Here is the change to remove it from the matrix.