### PR TITLE
Show commit subject when monitoring

### DIFF
--- a/lib/travis/cli/monitor.rb
+++ b/lib/travis/cli/monitor.rb
@@ -81,7 +81,8 @@ module Travis
         say [
           color(formatter.time(time), entity.color),
           color(entity.inspect_info, [entity.color, :bold]),
-          color(entity.state, entity.color)
+          color(entity.state, entity.color),
+          color(entity.commit.subject, entity.color)
         ].join(" ")
         notification.notify(entity.repository.slug, [
           entity.class.name[/[^:]+$/],


### PR DESCRIPTION
This makes it a bit easier to use the monitoring when on a project / organization with many builds happening by changing the output from:

```
2016-05-27 15:54:54 my_org/my_repo#42 passed
```

to:

```
2016-05-27 15:54:54 my_org/my_repo#42 passed Add monitoring
```
