### PR TITLE
Fix travis login issue

### DIFF
--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -331,8 +331,8 @@ module Travis
 
         def check_ssl
           raw(:head, '/') if ssl == SSL_OPTIONS
-        rescue SSLError => error
-          self.ssl = {}
+        rescue Exception => error
+          self.ssl = {} if error.class == Travis::Client::SSLError
         end
     end
   end


### PR DESCRIPTION
Travis API, `https://api.travis-ci.org/`, is returning 403 which caused `Travis::Client::Session#check_ssl` to throw an unexpected exception.

`#check_ssl` should really just check for `SSLError`. Fixed by rescuing `Exception` and set `ssl` to an empty hash if the error class is `SSLError`.
