### PR TITLE
Update restart for Travis API

### DIFF
--- a/lib/travis/client/methods.rb
+++ b/lib/travis/client/methods.rb
@@ -74,7 +74,7 @@ module Travis
         # btw, internally we call this reset, not restart, as it resets the state machine
         # but we thought that would be too confusing
         raise Error, "cannot restart a #{entity.class.one}" unless entity.restartable?
-        session.post_raw('/requests', "#{entity.class.one}_id" => entity.id)
+        session.post_raw("/#{entity.class.many}/#{entity.id}/restart")
         entity.reload
       end
 

--- a/spec/cli/restart_spec.rb
+++ b/spec/cli/restart_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe Travis::CLI::Restart do
   example 'travis restart' do
     run_cli('restart', '-t', 'token').should be_success
-    $params['build_id'].should be == "4125095"
-    $params['job_id'].should be_nil
+    $params['id'].should be == "4125095"
+    $params['entity'].should be == "builds"
   end
 
   example 'travis restart 6180.1' do
     run_cli('restart', '6180.1', '-t', 'token').should be_success
-    $params['build_id'].should be_nil
-    $params['job_id'].should be == "4125096"
+    $params['entity'].should be == "jobs"
+    $params['id'].should be == "4125096"
   end
 end

--- a/spec/support/fake_api.rb
+++ b/spec/support/fake_api.rb
@@ -714,9 +714,9 @@ module Travis
           }]}.to_json
         end
 
-        post '/requests' do
+        post '/:entity/:id/restart' do
           $params = params
-          "{}"
+          {}
         end
 
         post '/:entity/:id/cancel' do


### PR DESCRIPTION
I was unable to get restart working via the Travis CLI this morning and found out that the endpoint formerly used "POST /requests" is no longer documented on [the Travis API documentation](https://docs.travis-ci.com/api?ruby#requests). Every time I was trying to do a restart I was getting:

```
> travis restart 1837--debug
** Loading "/Users/<username>/.travis/config.yml"
** Loading gh
** GET "config"
**   took 0.93 seconds
** GitHub API: HEAD /repos/NetLogo/NetLogo
**   took 0.17 seconds
** GET "repos/NetLogo/NetLogo"
**   took 2.3 seconds
** GET "builds/" {:number=>"1837", :repository_id=>685178}
**   took 2 seconds
** GET "jobs/141467041"
**   took 1.6 seconds
** POST "requests" {"job_id"=>141467041}
**   took 1 seconds
resource not found ()
```

I was able to get it working by using the supported API endpoint, as shown in this PR.
