### PR TITLE
Use error.info[:error] if not nil

### DIFF
--- a/lib/travis/tools/github.rb
+++ b/lib/travis/tools/github.rb
@@ -245,7 +245,7 @@ module Travis
 
         def gh_error(error)
           raise error if explode
-          JSON.parse(error.info[:response_body])["message"].to_s
+          error.info[:error] || JSON.parse(error.info[:response_body])["message"].to_s
         end
 
         def debug(line)


### PR DESCRIPTION
I hit #190 and discovered error.info had `error` set, not `message`, causing a `ValueError` to be thrown from JSON.parse. Returning `error` seems appropriate, but please let me know if I should be fixing this some other way.

This fixes #190 
