### PR TITLE
Raise blacklist error on 403s

### DIFF
--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -218,7 +218,12 @@ module Travis
         when 301, 303      then raw(:get, result.headers['Location'])
         when 302, 307, 308 then raw(verb, result.headers['Location'])
         when 401           then raise Travis::Client::NotLoggedIn,      'not logged in'
-        when 403           then raise Travis::Client::NotLoggedIn,      'invalid access token'
+        when 403           then
+          if headers.key?("Authorization")
+            raise Travis::Client::NotLoggedIn,      'invalid access token'
+          else
+            raise Travis::Client::Error, "received 403 from %s; your IP may have been blacklisted" % [uri + url]
+          end
         when 404           then raise Travis::Client::NotFound,         result.body
         when 422           then raise Travis::Client::ValidationFailed, result.body
         when 400..499      then raise Travis::Client::Error,            "%s: %p" % [result.status, result.body]


### PR DESCRIPTION
According to @rkh on issue #315, the Travis API will return a 403 if the "quite aggressive" auto-blocking bot blacklists your IP address. This PR raises an appropriate Error, not a NotLoggedIn exception, if Travis API returns a 403 when the `Authorization` header is not set. I'm not sure if this is totally correct, though: ideally, the API would return a unique status code, like **503 Service Unavailable** with a huge `Retry-After`, so we could be absolutely sure. If we can do that, I'll update this PR accordingly.