### PR TITLE
Update typhoeus to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ gemspec
 
 gem 'rake', '~> 10.5.0' if RUBY_VERSION < '1.9.3'
 gem 'rake' if RUBY_VERSION >= '1.9.3'
-gem 'json' if RUBY_VERSION < '1.9'
+gem 'json', '< 2.0' if RUBY_VERSION < '2.2'
 gem 'highline', '~> 1.6.0' if RUBY_VERSION < '1.9.3'

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -308,7 +308,7 @@ Gem::Specification.new do |s|
   s.add_dependency "backports"
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "launchy",               "~> 2.1"
-  s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
+  s.add_dependency "typhoeus",              "~> 1.0"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"


### PR DESCRIPTION
Because of Gemfile solving, having typhoeus on an old version restricts the version we can use in our app. Tests still pass.