### PR TITLE
Warn users when setting env vars without '='

### DIFF
--- a/lib/travis/cli/encrypt.rb
+++ b/lib/travis/cli/encrypt.rb
@@ -36,6 +36,7 @@ module Travis
         end
 
         data = split? ? data.split("\n") : [data.strip]
+        warn_env_assignments(data)
         encrypted = data.map { |data| repository.encrypt(data) }
 
         if config_key
@@ -95,6 +96,12 @@ module Travis
                       end
 
           traverse_config(hash[key], *rest)
+        end
+
+        def warn_env_assignments(data)
+          if /env/.match(config_key) && data.find { |d| /=/.match(d).nil? }
+            warn "Environment variables in #{config_key} should be formatted as FOO=bar"
+          end
         end
     end
   end

--- a/spec/cli/encrypt_spec.rb
+++ b/spec/cli/encrypt_spec.rb
@@ -40,4 +40,10 @@ describe Travis::CLI::Encrypt do
     run_cli("encrypt", "foo=foo/bar").should be_success
     stderr.should_not match(/WARNING/)
   end
+
+  example "travis encrypt FOO bar -a" do
+    described_class.any_instance.stub(:save_travis_config)
+    run_cli("encrypt", "FOO", "bar", "-a").should be_success
+    stderr.should match(/Environment variables in env\.global should be formatted as FOO=bar/)
+  end
 end

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -310,6 +310,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
+  s.add_dependency "json",                  "~> 1.8" if RUBY_VERSION < "2.0"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "sinatra",   "~> 1.3"

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -306,6 +306,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday_middleware",    "~> 0.9", ">= 0.9.1"
   s.add_dependency "highline",              "~> 1.6"
   s.add_dependency "backports"
+  s.add_dependency "net-http-persistent",   "~> 2.9" if RUBY_VERSION < "2.1"
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "launchy",               "~> 2.1"
   s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"


### PR DESCRIPTION
Saving values that are not bash variable assignments makes
no sense in the context of a build environment.