### PR TITLE
Fix `travis login` for users with 2fa

### DIFF
--- a/lib/travis/tools/github.rb
+++ b/lib/travis/tools/github.rb
@@ -213,7 +213,7 @@ module Travis
 
       def login(user, password, die = true, otp = nil)
         basic_auth(user, password, die, otp) do |gh|
-          reply         = create_token(gh) #gh.post('/authorizations', :scopes => scopes, :note => note)
+          reply         = create_token(gh)
           auth_href     = reply['_links']['self']['href']
           self.callback = proc { with_otp(gh, user, otp) { |g| g.delete(auth_href) } } if drop_token
           reply['token']

--- a/lib/travis/tools/github.rb
+++ b/lib/travis/tools/github.rb
@@ -205,24 +205,38 @@ module Travis
       end
 
       def basic_auth(user, password, die = true, otp = nil, &block)
-        opt           = { :username => user, :password => password }
-        opt[:headers] = { "X-GitHub-OTP" => otp } if otp
-        yield GH.with(opt)
+        gh = GH.with(:username => user, :password => password)
+        with_otp(gh, user, otp, &block)
       rescue GH::Error => error
-        if error.info[:response_status] == 401 and error.info[:response_headers]['x-github-otp'].to_s =~ /required/
-          otp = ask_otp.arity == 0 ? ask_otp.call : ask_otp.call(user)
-          basic_auth(user, password, die, otp, &block)
-        elsif die
-          raise gh_error(error)
-        end
+        raise gh_error(error) if die
       end
 
       def login(user, password, die = true, otp = nil)
         basic_auth(user, password, die, otp) do |gh|
-          reply         = gh.post('/authorizations', :scopes => scopes, :note => note)
-          self.callback = proc { gh.delete reply['_links']['self']['href'] } if drop_token
+          reply         = create_token(gh) #gh.post('/authorizations', :scopes => scopes, :note => note)
+          auth_href     = reply['_links']['self']['href']
+          self.callback = proc { with_otp(gh, user, otp) { |g| g.delete(auth_href) } } if drop_token
           reply['token']
         end
+      end
+
+      def create_token(gh)
+        gh.post('/authorizations', :scopes => scopes, :note => note)
+      rescue GH::Error => error
+        # token might already exist due to bug in earlier CLI version, we'll have to delete it first
+        raise error unless error.info[:response_status] == 422 and error.info[:response_body].to_s =~ /already_exists/
+        raise error unless reply = gh['/authorizations'].detect { |a| a['note'] == note }
+        gh.delete(reply['_links']['self']['href'])
+        retry
+      end
+
+      def with_otp(gh, user, otp, &block)
+        gh = GH.with(gh.options.merge(:headers => { "X-GitHub-OTP" => otp })) if otp
+        block.call(gh)
+      rescue GH::Error => error
+        raise error unless error.info[:response_status] == 401 and error.info[:response_headers]['x-github-otp'].to_s =~ /required/
+        otp = ask_otp.arity == 0 ? ask_otp.call : ask_otp.call(user)
+        retry
       end
 
       def acceptable?(token)


### PR DESCRIPTION
This pull request does two things:

* Use OTP for deleting temporary token, if OTP is expired prompt user for a new on. This fixes the login for any user that has 2fa enabled on GitHub.
* If a token with the same note already exists, delete it. This fixes the login command for any user for whom the command previously aborted after creating the token.

See https://github.com/travis-pro/team-teal/issues/1456