### PR TITLE
fix the error on report when the enterprise config doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 spec/tmp
 doc
+.ruby*

--- a/lib/travis/cli/report.rb
+++ b/lib/travis/cli/report.rb
@@ -80,7 +80,7 @@ module Travis
         when Travis::Client::PRO_URI  then "#{prefix}pro"
         when /api-staging\.travis-ci/ then endpoint_name(url.sub("api-staging.", "api."), "staging-")
         else
-          key, _ = config['enterprise'].detect { |k,v| v.start_with? url }
+          key, _ = config['enterprise'].detect { |k,v| v.start_with? url } if config['enterprise'].respond_to?(:detect)
           key ? "enterprise %p" % key : "???"
         end
       end


### PR DESCRIPTION
This was masking the last exception from the report.