### PR TITLE
Fix Pypi distributions

### DIFF
--- a/lib/travis/cli/setup/pypi.rb
+++ b/lib/travis/cli/setup/pypi.rb
@@ -8,12 +8,11 @@ module Travis
 
         def run
           deploy 'pypi', 'release' do |config|
-            config['user']     ||= ask("Username: ").to_s
-            config['password'] ||= ask("Password: ") { |q| q.echo = "*" }.to_s
+            config['user']          ||= ask("Username: ").to_s
+            config['password']      ||= ask("Password: ") { |q| q.echo = "*" }.to_s
+            config['distributions'] ||= ask("Distributions to deploy: ") { |q| q.default = 'sdist' }.to_s
 
             on("release only tagged commits? ", config, 'tags' => true)
-            # the default of pypi `setup.py build` is the `sdist`
-            on("deploy as wheel file too? ", config, 'distributions' => 'sdist bdist_wheel')
           end
         end
       end


### PR DESCRIPTION
Currently, distributions was being put under the "on:" section of the
.travis.yml file. According to the documentation [0], the distributions
key was expected to be right under "deploy".

This commit changes the code so the right question is asked (Which
distributions would you like to publish) and defaults to the Travis'
current default of "sdist".

[0] https://docs.travis-ci.com/user/deployment/pypi/