### PR TITLE
auto_login: Fix logic error

### DIFF
--- a/lib/travis/client/auto_login.rb
+++ b/lib/travis/client/auto_login.rb
@@ -17,7 +17,7 @@ module Travis
       end
 
       def authenticate
-        return unless session.access_token = cli_token
+        return if session.access_token = cli_token
         github.with_token { |t| session.github_auth(t) }
       end
 


### PR DESCRIPTION
A logic error prevented the `authenticate` method from working properly
if a valid access token was already stored in the configuration file.
Fix that bug by skipping GitHub authentication if a valid token already
exists.