### PR TITLE
uses system CAs instead of given 3 CAs for Travis CI Enterprise

### DIFF
--- a/lib/travis/cli/api_command.rb
+++ b/lib/travis/cli/api_command.rb
@@ -108,7 +108,7 @@ module Travis
             endpoint
           end
           self.api_endpoint             = c[enterprise_name]
-          self.insecure                 = true if insecure.nil?
+          self.insecure                 = insecure unless insecure.nil?
           endpoint_config['enterprise'] = true
           @setup_ennterpise             = true
         end

--- a/lib/travis/cli/api_command.rb
+++ b/lib/travis/cli/api_command.rb
@@ -109,6 +109,7 @@ module Travis
           end
           self.api_endpoint             = c[enterprise_name]
           self.insecure                 = insecure unless insecure.nil?
+          self.session.ssl.delete :ca_file
           endpoint_config['enterprise'] = true
           @setup_ennterpise             = true
         end

--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -17,7 +17,7 @@ module Travis
   module Client
     class Session
       PRIMITIVE   = [nil, false, true]
-      SSL_OPTIONS = {}
+      SSL_OPTIONS = { :ca_file => Tools::Assets['cacert.pem'] }
 
       include Methods
       attr_reader :connection, :headers, :access_token, :instruments, :faraday_adapter, :agent_info, :ssl

--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -17,7 +17,7 @@ module Travis
   module Client
     class Session
       PRIMITIVE   = [nil, false, true]
-      SSL_OPTIONS = { :ca_file => Tools::Assets['cacert.pem'] }
+      SSL_OPTIONS = {}
 
       include Methods
       attr_reader :connection, :headers, :access_token, :instruments, :faraday_adapter, :agent_info, :ssl

--- a/spec/cli/api_command_spec.rb
+++ b/spec/cli/api_command_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Travis::CLI::ApiCommand do
+  describe 'enterprise' do
+    travis_config_path = ENV['TRAVIS_CONFIG_PATH']
+
+    before do
+      ENV['TRAVIS_CONFIG_PATH'] = File.expand_path '../support', File.dirname(__FILE__)
+      config = subject.send(:load_file, 'fake_travis_config.yml')
+      subject.config = YAML.load(config)
+
+      subject.api_endpoint = 'https://travis-ci-enterprise/api'
+      subject.enterprise_name = 'default'
+    end
+
+    after do
+      ENV['TRAVIS_CONFIG_PATH'] = travis_config_path
+    end
+
+    describe '#setup_enterprise' do
+      before do
+        subject.send(:setup_enterprise)
+      end
+
+      it 'keeps verifying peers' do
+        subject.insecure.should be_false
+      end
+
+      it 'flags endpoint' do
+        subject.endpoint_config.should include('enterprise' => true)
+      end
+    end
+  end
+end

--- a/spec/cli/api_command_spec.rb
+++ b/spec/cli/api_command_spec.rb
@@ -26,6 +26,10 @@ describe Travis::CLI::ApiCommand do
         subject.insecure.should be_falsey
       end
 
+      it 'uses default CAs' do
+        subject.session.ssl.should_not include(:ca_file)
+      end
+
       it 'flags endpoint' do
         subject.endpoint_config.should include('enterprise' => true)
       end

--- a/spec/cli/api_command_spec.rb
+++ b/spec/cli/api_command_spec.rb
@@ -23,7 +23,7 @@ describe Travis::CLI::ApiCommand do
       end
 
       it 'keeps verifying peers' do
-        subject.insecure.should be_false
+        subject.insecure.should be_falsey
       end
 
       it 'flags endpoint' do

--- a/spec/support/fake_travis_config.yml
+++ b/spec/support/fake_travis_config.yml
@@ -10,3 +10,5 @@ endpoints:
     access_token: fake-travis-com-token
   https://api.travis-ci.org/:
     access_token: fake-travis-org-token
+  https://travis-ci-enterprise/api:
+    access_token: fake-travis-enterprise-token


### PR DESCRIPTION
a follow up of https://github.com/travis-ci/travis.rb/issues/141#issuecomment-285496095

I would like to keep the same SSL/TLS verification for both travis-ci.org and Travis CI enterprise.