### PR TITLE
Macintosh OS Serria (10.12.4) Instruction Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1993,6 +1993,7 @@ Mac OSX prior to 10.9 ships with a very dated Ruby version. You can use [Homebre
 
     $ brew install ruby
     $ gem update --system
+    $ sudo gem install -n /usr/local/bin travis -v 1.8.8 --no-rdoc --no-ri
 
 #### Windows
 


### PR DESCRIPTION
Now Macintosh is rootless, we need specify install path rather than default path

Refer : [http://stackoverflow.com/questions/32891965/error-while-executing-gem-errnoeperm-operation-not-permitted](http://stackoverflow.com/questions/32891965/error-while-executing-gem-errnoeperm-operation-not-permitted)