### PR TITLE
assets/init/node_js: Update default Node.js versions

### DIFF
--- a/assets/init/node_js.yml
+++ b/assets/init/node_js.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-- "0.11"
-- "0.10"
+- "stable"
+- "6"
+- "4"

--- a/spec/cli/init_spec.rb
+++ b/spec/cli/init_spec.rb
@@ -139,8 +139,9 @@ describe Travis::CLI::Init do
 
     it 'sets compiler' do
       result.should include('node_js')
-      result['node_js'].should include('0.11')
-      result['node_js'].should include('0.10')
+      result['node_js'].should include('stable')
+      result['node_js'].should include('6')
+      result['node_js'].should include('4')
     end
   end
 


### PR DESCRIPTION
Node 0.11 and 0.10 are no longer supported by Node.js. Node 6 and 4 are the current LTS releases and `stable` will always install the most recent stable release (7.x at this time).