### PR TITLE
Remove Ruby 2.1.0 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - 1.9.2
 - 1.9.3
 - 2.0.0
-- 2.1.0
 - 2.1.3
 - jruby
 os:
@@ -16,8 +15,6 @@ matrix:
   - rvm: 1.8.7
     os: osx
   - rvm: 1.9.2
-    os: osx
-  - rvm: 2.1.0
     os: osx
   - rvm: jruby
     os: osx


### PR DESCRIPTION
Trusty does not have Ruby 2.1.0 available: https://travis-ci.org/travis-ci/travis.rb/jobs/266765923