### PR TITLE
Enable Faraday logger universally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ deploy:
     repo: travis-ci/travis.rb
     ruby: 2.0.0
     condition: "$(uname) = Linux"
+    branch: debug

--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -59,7 +59,7 @@ module Travis
         clear_cache!
         self.connection = Faraday.new(:url => uri, :ssl => ssl) do |faraday|
           faraday.request  :url_encoded
-          faraday.response :logger if debug_http
+          faraday.response :logger
           faraday.adapter(*faraday_adapter)
         end
       end

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -318,6 +318,6 @@ Gem::Specification.new do |s|
   if ENV['TRAVIS_JOB_NUMBER'] and ENV['TRAVIS_REPO_SLUG'] == 'travis-ci/travis.rb'
     digits = s.version.to_s.split '.'
     digits[-1] = digits[-1].to_s.succ
-    s.version = digits.join('.') + ".travis.#{ENV['TRAVIS_JOB_NUMBER']}"
+    s.version = digits.join('.') + ".travis.#{ENV['TRAVIS_JOB_NUMBER']}-debug"
   end
 end


### PR DESCRIPTION
Passing down `debug_http` from the command line to Session
require some more work, so we will build gem that has it on
universally