### PR TITLE
notifications: Use OS X's pgrep

### DIFF
--- a/lib/travis/tools/system.rb
+++ b/lib/travis/tools/system.rb
@@ -81,7 +81,7 @@ module Travis
 
       def running?(app)
         return false unless unix?
-        system "pgrep -u $(whoami) #{app} >/dev/null"
+        system "/usr/bin/pgrep -u $(whoami) #{app} >/dev/null"
       end
     end
   end


### PR DESCRIPTION
Always use OS X's  BSD `pgrep` instead of (for example)
the proctools version that is in the `PATH` earlier.