### PR TITLE
Loosen Typhoeus gem version restriction so that it allows for usage of v1.x

### DIFF
--- a/travis.gemspec
+++ b/travis.gemspec
@@ -339,7 +339,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "addressable",           "~> 2.4.0" if RUBY_VERSION < "2.0"
   s.add_dependency "launchy",               "~> 2.1"
-  s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
+  s.add_dependency "typhoeus",              ">= 0.6.8", "< 2.0"
   s.add_dependency "json",                  "~> 1.8" if RUBY_VERSION < "2.0"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_development_dependency "rspec",     "~> 2.12"


### PR DESCRIPTION
[Typoheus](https://github.com/typhoeus/typhoeus) `v1.0` was released over 2 years ago with no major API changes from what I can tell. I don't understand why the gemspec for this project has the dependency locked to `v0.x`

Looking at commit history, it seems like the current version restriction dates back to #188, which also appears to be a PR to loosen the dependency.

I'd like to use this gem in a project that has a dependency on Typhoeus v1+. This appears to still install fine and all specs passed with Typhoeus `v1.3.0` installed for the project on my local system, so unless there is an objection it would be nice to see this change made. Thanks for your consideration.