### PR TITLE
Fix nil error during travis branches command

### DIFF
--- a/lib/travis/cli/branches.rb
+++ b/lib/travis/cli/branches.rb
@@ -18,7 +18,7 @@ module Travis
       private
 
         def longest
-          repository.branches.keys.map { |b| b.size }.max
+          repository.branches.keys.compact.map { |b| b.size }.max
         end
     end
   end


### PR DESCRIPTION
Not sure why a branch pops up in `travis branches` output with no branch name. This branch causes the error mentioned in #552 

Here's what the output looks like with the fix.
```
some-poc:                        #814  passed     Fix something
:                                #803  failed     [BUG-3795] Fix something else
dev:                             #780  errored    Merge pull request #198
```