### PR TITLE
Do not fail .bashrc if travis is not installed

### DIFF
--- a/lib/travis/tools/completion.rb
+++ b/lib/travis/tools/completion.rb
@@ -25,7 +25,7 @@ module Travis
         RCS.each do |file|
           next unless File.exist? file and File.writable? file
           next if File.read(file).include? source
-          File.open(file, "a") { |f| f.puts("", "# added by travis gem", "[ -f #{cmp_file} ] && #{source}") }
+          File.open(file, "a") { |f| f.puts("", "# added by travis gem", "[ ! -s #{cmp_file} ] || #{source}") }
         end
       end
 


### PR DESCRIPTION
Currently installing travis (bash completion) might add something like this into your .bashrc:

```
# added by travis gem
[ -f /Users/guenter/.travis/travis.sh ] && source /Users/guenter/.travis/travis.sh
```

This will unfortunately cause bash to spawn with a return-code of 1.

My fix will solve this issue and make sure that it will work if those files exist, and that it won't throw an error should they not exist:

```
    [ ! -s ~/.bashrc ] || echo yes; echo $? # file exists, outputs "yes", rc=0
yes
0
    [ ! -s ~/.bashrrc ] || echo yes; echo $? # file does not exist, outputs nothing, rc=0
0
    [ -s ~/.bashrc ] && echo yes; echo $? # file exists, outputs "yes", rc=0
yes
0
    [ -s ~/.bashrrc ] && echo yes; echo $? # file does not exist, outputs nothing, rc=1
1
```