### PR TITLE
Optimize .travis.yml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,41 @@
 language: ruby
-sudo: false
 cache: bundler
-rvm:
-- 1.9.2
-- 1.9.3
-- 2.0.0
-- 2.1.0
-- 2.1.3
-- jruby
+
 os:
-- linux
-- osx
+  - linux
+  - osx
+
+rvm:
+  - jruby
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.1.5
+
+jobs:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      rvm: 1.9.3
+    - stage: deploy
+      if: branch = master
+      os: linux
+      rvm: 2.0.0
+      deploy:
+        provider: rubygems
+        api_key:
+          secure: KcBpkFaes74KGMm8X/rRA8e13+t3PmkefsAvOAR+iF4g1GyuLSPkP92Fb9vFfsXBph+qmFh5rNa2lIRf/3RXW6COxY7CMMaARxUfJOKE0rmIwF0qfKI+RZDh6abg92iYngunMZVN8WVft6Lv9ZTOYCWxr1Zs1Ll/Rl4PfvHNd1g=
+        gem: travis
+        on:
+          repo: travis-ci/travis.rb
+          ruby: 2.0.0
+
 matrix:
   exclude:
-  - rvm: 1.8.7
-    os: osx
-  - rvm: 1.9.2
-    os: osx
-  - rvm: 2.1.0
-    os: osx
-  - rvm: jruby
-    os: osx
-deploy:
-  provider: rubygems
-  api_key:
-    secure: KcBpkFaes74KGMm8X/rRA8e13+t3PmkefsAvOAR+iF4g1GyuLSPkP92Fb9vFfsXBph+qmFh5rNa2lIRf/3RXW6COxY7CMMaARxUfJOKE0rmIwF0qfKI+RZDh6abg92iYngunMZVN8WVft6Lv9ZTOYCWxr1Zs1Ll/Rl4PfvHNd1g=
-  gem: travis
-  on:
-    repo: travis-ci/travis.rb
-    ruby: 2.0.0
-    condition: "$(uname) = Linux"
+    - rvm: 1.9.2
+      os: osx
+    - rvm: 1.9.3
+      os: osx
+    - rvm: jruby
+      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,15 @@ rvm:
   - 2.1.0
   - 2.1.5
 
+matrix:
+  exclude:
+    - rvm: 1.9.2
+      os: osx
+    - rvm: 1.9.3
+      os: osx
+    - rvm: jruby
+      os: osx
+
 jobs:
   include:
     - os: osx
@@ -30,12 +39,3 @@ jobs:
         on:
           repo: travis-ci/travis.rb
           ruby: 2.0.0
-
-matrix:
-  exclude:
-    - rvm: 1.9.2
-      os: osx
-    - rvm: 1.9.3
-      os: osx
-    - rvm: jruby
-      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 
 os:
   - linux
-  - osx
 
 rvm:
   - jruby
@@ -13,20 +12,17 @@ rvm:
   - 2.1.0
   - 2.1.5
 
-matrix:
-  exclude:
-    - rvm: 1.9.2
-      os: osx
-    - rvm: 1.9.3
-      os: osx
-    - rvm: jruby
-      os: osx
-
 jobs:
   include:
     - os: osx
       osx_image: xcode7.3
       rvm: 1.9.3
+    - os: osx
+      rvm: 2.0.0
+    - os: osx
+      rvm: 2.1.0
+    - os: osx
+      rvm: 2.1.5
     - stage: deploy
       if: branch = master
       os: linux


### PR DESCRIPTION
   - test both latest Linux and macOS versions for Ruby 2.0.0, 2.1.0 and 2.1.5
   - test travis.rb on macOS xcode7.3 with Ruby 1.9.3
   - test ruby 1.9.2 and jruby on latest Linux
   - skip 1.9.2 and jruby versions on mac
   - use build stages to deploy
   - remove custom condition to deploy, now deploys IF branch =  master <-> the previous stage builds successfully

@rkh  can you take a look? I've adjusted this just so we release a new GEM when building Linux & Ruby 2.0.0 on the `master` branch. 

In your opinion, is there anything we should add to deploy development releases? Thank you! 