### PR TITLE
Fix cli encrypt-file multi-file issue outlined in #627

### DIFF
--- a/lib/travis/cli/encrypt_file.rb
+++ b/lib/travis/cli/encrypt_file.rb
@@ -37,7 +37,7 @@ module Travis
 
           error "requires --decrypt-to option when reading from stdin" unless decrypt_to?
 
-          set_env_vars
+          set_env_vars(input_path)
 
           command = decrypt_command(output_path)
           stage ? store_command(command) : print_command(command)
@@ -70,14 +70,14 @@ module Travis
         "openssl aes-256-cbc -K $#{env_name(:key)} -iv $#{env_name(:iv)} -in #{escape_path(path)} -out #{escape_path(decrypt_to)} -d"
       end
 
-      def set_env_vars
+      def set_env_vars(input_path)
         say "storing secure env variables for decryption"
-        repository.env_vars.upsert env_name(:key), key, :public => false
-        repository.env_vars.upsert env_name(:iv),  iv,  :public => false
+        repository.env_vars.upsert env_name(:key, input_path), key, :public => false
+        repository.env_vars.upsert env_name(:iv, input_path),  iv,  :public => false
       end
 
-      def env_name(name)
-        @env_prefix ||= "encrypted_#{Digest.hexencode(Digest::SHA1.digest(Dir.pwd)[0..5])}"
+      def env_name(name, input_path)
+        @env_prefix ||= "encrypted_#{Digest.hexencode(Digest::SHA1.digest(input_path)[0..5])}"
         "#{@env_prefix}_#{name}"
       end
 


### PR DESCRIPTION
This fixes a longstanding issue with the use of the cli `encrypt-file` with multiple files. This issue occurs when the command is invoked from the same working folder due to how the environment name is computed from the working folder instead of the input_file path.  See #627 for full details
