### PR TITLE
Pry: prompt-related code was moved

### DIFF
--- a/lib/travis/cli/console.rb
+++ b/lib/travis/cli/console.rb
@@ -14,7 +14,7 @@ module Travis
 
         Object.send(:include, Client::Namespace.new(session))
         hooks = defined?(Pry::Hooks) ? Pry::Hooks.new : {}
-        binding.pry(:quiet => true, :prompt => Pry::SIMPLE_PROMPT, :output => $stdout, :hooks => hooks)
+        binding.pry(:quiet => true, :prompt => Pry::Prompt[:simple][:value], :output => $stdout, :hooks => hooks)
       end
 
       private


### PR DESCRIPTION
Prompt-related code for pry changed a few times in the past weeks. Most notably in these commits:

  - https://github.com/pry/pry/commit/23a4ac6f0b2715b94877bafb384afbffc45b583a
  - https://github.com/pry/pry/commit/3da930f908ff73f7638bd0471c25d47c28320df3

This commit makes use of the new prompt API and avoids `uninitialized constant Pry::SIMPLE_PROMPT` errors.