### PR TITLE
Convert /logs/:id API result to fix #578

### DIFF
--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -316,7 +316,13 @@ module Travis
         end
 
         def fetch_one(entity, id = nil)
-          get("/#{entity.base_path}/#{id}")[entity.one]
+          path = "/#{entity.base_path}/#{id}"
+
+          if entity == Travis::Client::Artifact
+            load({'log' => {'id' => id, 'body' => get_raw(path)}})[entity.one]
+          else
+            get(path)[entity.one]
+          end
         end
 
         def fetch_many(entity, params = {})


### PR DESCRIPTION
I can't find any document about the previous format for `/logs/:id` but I guess it was like this:

```json
{"log": {"id": 123, "body": "travis_fold:start:worker_info..."}}
```