### PR TITLE
Change permissions required to set env variables

### DIFF
--- a/lib/travis/cli/env.rb
+++ b/lib/travis/cli/env.rb
@@ -15,7 +15,7 @@ module Travis
       def setup
         super
         authenticate
-        error "not allowed to access environment variables for #{color(repository.slug, :bold)}" unless repository.admin?
+        error "not allowed to access environment variables for #{color(repository.slug, :bold)}" unless repository.push? && repository.pull?
       end
 
       def set(name, value)


### PR DESCRIPTION
A user shouldn't have to be an admin in order to update env variables via the CLI. Push and Pull access should be enough.

Fixes https://github.com/travis-ci/travis.rb/issues/609


Not sure why the build is failing, the message isn't immediately clear, but if someone could offer some guidance I would be more than happy to fix it. 