### PR TITLE
Fix broken installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1967,7 +1967,7 @@ You can check your Ruby version by running `ruby -v`:
 
 Then run:
 
-    $ gem install travis -v 1.8.9 --no-rdoc --no-ri
+    $ gem install travis -v 1.8.9 --no-document
 
 Now make sure everything is working:
 


### PR DESCRIPTION
--rdoc and --ri flags in gem cli are now deprecated and have been replaced by --no-document

Refer to https://github.com/rubygems/rubygems/pull/2354