### PR TITLE
Properly handle migrated repositories

### DIFF
--- a/lib/travis/cli/command.rb
+++ b/lib/travis/cli/command.rb
@@ -201,6 +201,9 @@ module Travis
       rescue Travis::Client::NotLoggedIn => e
         raise(e) if explode?
         error "#{e.message} - try running #{command("login#{endpoint_option}")}"
+      rescue Travis::Client::RepositoryMigrated => e
+        raise (e) if explode?
+        error e.message
       rescue Travis::Client::NotFound => e
         raise(e) if explode?
         error "resource not found (#{e.message})"

--- a/lib/travis/client/error.rb
+++ b/lib/travis/client/error.rb
@@ -14,6 +14,9 @@ module Travis
     class NotLoggedIn < Error
     end
 
+    class RepositoryMigrated < Error
+    end
+
     class ValidationFailed < Error
       attr_reader :errors
 

--- a/lib/travis/client/session.rb
+++ b/lib/travis/client/session.rb
@@ -218,7 +218,13 @@ module Travis
         when 301, 303      then raw(:get, result.headers['Location'])
         when 302, 307, 308 then raw(verb, result.headers['Location'])
         when 401           then raise Travis::Client::NotLoggedIn,      'not logged in'
-        when 403           then raise Travis::Client::NotLoggedIn,      'invalid access token'
+        when 403           then
+          body = JSON.parse(result.body) rescue {}
+          if body["error_type"] == "migrated_repository"
+            raise Travis::Client::RepositoryMigrated, body["error_message"]
+          else
+            raise Travis::Client::NotLoggedIn,      'invalid access token'
+          end
         when 404           then raise Travis::Client::NotFound,         result.body
         when 422           then raise Travis::Client::ValidationFailed, result.body
         when 400..499      then raise Travis::Client::Error,            "%s: %p" % [result.status, result.body]


### PR DESCRIPTION
When trying to modify a repository migrated to .com the API will return
403 error. Before this commit it was always interpreted as an invalid
token. Now we will output a proper error message.