### PR TITLE
Add option to see duration in history output

### DIFF
--- a/lib/travis/cli/history.rb
+++ b/lib/travis/cli/history.rb
@@ -10,6 +10,7 @@ module Travis
       on('-b', '--branch BRANCH', 'Only show history for the given branch')
       on('-l', '--limit LIMIT', 'Maximum number of history items')
       on('-d', '--date', 'Include date in output')
+      on('-t', '--duration', 'Include build time in secs in output')
       on('-c', '--committer', 'Include committer in output')
       on('--[no-]all', 'Display all history items')
 
@@ -39,6 +40,7 @@ module Travis
           say [
             date? && color(formatter.time(build.finished_at || build.started_at), build.color),
             color("##{build.number} #{build.state}:".ljust(16), [build.color, :bold]),
+            duration? && color(build.duration.to_s.ljust(6), :info),
             color("#{build.branch_info}", :info),
             committer? && build.commit.author_name.ljust(25),
             build.commit.subject

--- a/spec/cli/history_spec.rb
+++ b/spec/cli/history_spec.rb
@@ -35,4 +35,9 @@ describe Travis::CLI::History do
     run_cli('history', '-c').should be_success
     stdout.should be == "#6180 failed:    master Steve Klabnik             Associaton -> Association\n"
   end
+
+  example 'travis history -t' do
+    run_cli('history', '-t').should be_success
+    stdout.should be == "#6180 failed:    5019   master Associaton -> Association\n"
+  end
 end


### PR DESCRIPTION
The flag `--time` was not used a `time` is already a `Command::time`
method.
The flag `-d` was not used as already used for `--date`

This is useful for looking at trends in build times