### PR TITLE
chore: update to build image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Travis Client [![Build Status](https://travis-ci.com/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.org/travis-ci/travis.rb)
+# The Travis Client [![Build Status](https://travis-ci.com/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.com/travis-ci/travis.rb)
 
 ![The Travis Mascot](http://about.travis-ci.org/images/travis-mascot-200px.png)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Travis Client [![Build Status](https://travis-ci.org/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.org/travis-ci/travis.rb)
+# The Travis Client [![Build Status](https://travis-ci.com/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.org/travis-ci/travis.rb)
 
 ![The Travis Mascot](http://about.travis-ci.org/images/travis-mascot-200px.png)
 


### PR DESCRIPTION
### Description
This quick PR updates the build image to use `.com` instead of `.org` for the image source as well as the link. Below 

Fixed example in this PR : when you click `.com`
# The Travis Client [![Build Status](https://travis-ci.com/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.com/travis-ci/travis.rb)

where as `.org` results in "This repository was migrated and is now building on travis-ci.com" 
**broken** example:
# The Travis Client [![Build Status](https://travis-ci.org/travis-ci/travis.rb.svg?branch=master)](https://travis-ci.org/travis-ci/travis.rb)

