### PR TITLE
Reversing the order of the `fetch_token` function

### DIFF
--- a/lib/travis/cli/api_command.rb
+++ b/lib/travis/cli/api_command.rb
@@ -175,7 +175,7 @@ module Travis
         end
 
         def fetch_token
-          ENV['TRAVIS_TOKEN'] || endpoint_config['access_token']
+          endpoint_config['access_token'] || ENV['TRAVIS_TOKEN']
         end
     end
   end


### PR DESCRIPTION
Reversing the order of the `fetch_token` function allowing users to login and use that token instead of the environment variable first.

Fix for https://github.com/travis-ci/travis.rb/issues/694