### PR TITLE
Add --env-prefix to encrypt-file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ There are two ways the client can treat existing values:
         -R, --store-repo SLUG            like --repo, but remembers value for current directory
         -K, --key KEY                    encryption key to be used (randomly generated otherwise)
             --iv IV                      encryption IV to be used (randomly generated otherwise)
+            --env-prefix ENV_PREFIX      prefix of the names of the encryption key/IV environment variables (randomly generated otherwise)
         -d, --decrypt                    decrypt the file instead of encrypting it, requires key and iv
         -f, --force                      override output file if it exists
         -p, --print-key                  print (possibly generated) key and iv

--- a/lib/travis/cli/encrypt_file.rb
+++ b/lib/travis/cli/encrypt_file.rb
@@ -14,6 +14,7 @@ module Travis
       description 'encrypts a file and adds decryption steps to .travis.yml'
       on '-K', '--key KEY', 'encryption key to be used (randomly generated otherwise)'
       on '--iv IV', 'encryption IV to be used (randomly generated otherwise)'
+      on '--env-prefix ENV_PREFIX', 'prefix of the names of the encryption key/IV environment variables (randomly generated otherwise)'
       on '-d', '--decrypt', 'decrypt the file instead of encrypting it, requires key and iv'
       on '-f', '--force', 'override output file if it exists'
       on '-p', '--print-key', 'print (possibly generated) key and iv'


### PR DESCRIPTION
When running the `encrypt-file command`, the travis client adds two encrypted environment variables to the project configuration (for example: `encrypted_123456789ab_key` and `encrypted_123456789ab_iv`).

The prefix of the name of these two variables is randomly generated.

In order to specify this prefix we can now use this new `--env-prefix` option.

For example:
```
travis encrypt-file --env-prefix myprefix
```

will generate two variables named `myprefix_key` and `myprefix_iv`