### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2058,6 +2058,12 @@ For newer versions of Ubuntu (16.04 and above), it should be enough to run:
 
     $ sudo apt-get install ruby-dev
 
+If you have error about `mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h`
+```console
+# try to run following cmd
+sudo apt install ruby-dev libffi-dev make gcc
+sudo gem install travis
+```
 #### Mac OS X
 
 If you start with a clean Mac OS X, you will have to install the XCode Command Line Tools, which are necessary for installing native extensions. You can do so via `xcode-select`:

--- a/README.md
+++ b/README.md
@@ -2061,7 +2061,7 @@ For newer versions of Ubuntu (16.04 and above), it should be enough to run:
 If you have error about `mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h`
 ```console
 # try to run following cmd
-sudo apt install ruby-dev libffi-dev make gcc
+sudo apt-get install ruby-dev libffi-dev make gcc -y
 sudo gem install travis
 ```
 #### Mac OS X


### PR DESCRIPTION
# spec
```
Ubuntu LTS 18.x @ window WSL

ruby -v                  
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]
```
# error
```console
Building native extensions. This could take a while...
ERROR:  Error installing travis:
        ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.5.0/gems/ffi-1.11.2/ext/ffi_c
/usr/bin/ruby2.5 -r ./siteconf20191116-5503-13ogt73.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h

extconf failed, exit code 1
```

# solution
```console
sudo apt-get install ruby-dev libffi-dev make gcc -y
sudo gem install travis
```