### PR TITLE
setup: add skip_cleanup for dpl v1

### DIFF
--- a/lib/travis/cli/setup/service.rb
+++ b/lib/travis/cli/setup/service.rb
@@ -63,6 +63,8 @@ module Travis
               on("#{verb.capitalize} only from #{repository.slug}? ", config, 'repo' => repository.slug)
               on("#{verb.capitalize} from #{branch} branch? ", config, 'branch' => branch) if branch != 'master' and branch != 'HEAD'
 
+              config['skip_cleanup'] = 'true' if not ( config.has_key?('skip_cleanup') or config.fetch('edge', 'false') != 'false' )
+
               encrypt(config, 'password') if config['password'] and agree("Encrypt Password? ") { |q| q.default = 'yes' }
               encrypt(config, 'api_key')  if config['api_key']  and agree("Encrypt API key? ") { |q| q.default = 'yes' }
             end

--- a/spec/cli/setup/service_spec.rb
+++ b/spec/cli/setup/service_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Travis::CLI::Setup::Service do
+  subject :service do
+    repository = double('repository',{:slug => 'test_slug'})
+    setup = double('Setup', :repository => repository)
+    described_class.new(setup)
+  end
+  
+  describe '#deploy' do
+  
+    subject :deploy_config do
+      {'provider' => 'dummy'}
+    end
+    
+    before do
+      allow(service).to receive(:configure).and_yield(deploy_config)
+      allow(service).to receive(:on).and_return(nil)
+    end
+  
+    context 'with no existing deploy section' do
+    
+      it 'creates section contents without optional items' do
+        service.send(:deploy, 'dummy') { |_| }
+        expect(deploy_config).to include(
+            'provider'      => 'dummy',
+            'skip_cleanup'   => 'true'
+        )
+      end
+    end
+    
+    context 'with existing deploy section' do
+      it 'doesn\'t overwrite existing skip_cleanup' do
+        deploy_config['skip_cleanup']='false'
+        service.send(:deploy, 'dummy') { |_| }
+        expect(deploy_config).to include('skip_cleanup'   => 'false')
+      end
+
+      it 'doesn\'t set skip_cleanup for v2' do
+        deploy_config['edge']='true'
+        service.send(:deploy, 'dummy') { |_| }
+        expect(deploy_config).not_to include('skip_cleanup')
+      end
+      
+      it 'sets skip_cleanup for explicit v1' do
+        deploy_config['edge']='false'
+        service.send(:deploy, 'dummy') { |_| }
+        expect(deploy_config).to include('skip_cleanup'   => 'true')
+      end
+    end
+    
+  end
+end

--- a/spec/client/auto_login_spec.rb
+++ b/spec/client/auto_login_spec.rb
@@ -9,7 +9,7 @@ describe Travis::Client::AutoLogin do
   context "authenticate" do
     context "when user has a token in cli config" do
       it "does not call Tools::Github#with_token" do
-        expect(Travis::Tools::Github.any_instance).to_not receive(:with_token)
+        expect_any_instance_of(Travis::Tools::Github).to_not receive(:with_token)
         auto_login_with_token.authenticate
       end
     end


### PR DESCRIPTION
https://travis-ci.community/t/include-skip-cleanup-true-in-travis-setup-releases/7006

Added this into the base class since cases where `skip_cleanup` is not needed are rare.

* Detecting dpl v2 by `edge:` -- don't see any other methods to do that.