### PR TITLE
Fix the gem install command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1967,7 +1967,9 @@ You can check your Ruby version by running `ruby -v`:
 
 Then run:
 
-    $ gem install travis -v 1.8.10 --no-rdoc --no-ri
+    $ gem install travis -v 1.8.10 --no-document
+
+(For older versions of `gem`, replace `--no-document` with `--no-rdoc --no-ri`.)
 
 Now make sure everything is working:
 


### PR DESCRIPTION
The `gem --no-rdoc` and `--no-ri` switches are deprecated:

```
$ gem install travis -v 1.8.10 --no-rdoc --no-ri
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
$ gem --version
3.0.6
```

This commit updates the installation instructions in the readme with the new syntax.