### PR TITLE
Add bare minimum encrypt-file spec and fix the command

### DIFF
--- a/lib/travis/cli/encrypt_file.rb
+++ b/lib/travis/cli/encrypt_file.rb
@@ -67,7 +67,7 @@ module Travis
       end
 
       def decrypt_command(path)
-        "openssl aes-256-cbc -K $#{env_name(:key)} -iv $#{env_name(:iv)} -in #{escape_path(path)} -out #{escape_path(decrypt_to)} -d"
+        "openssl aes-256-cbc -K $#{env_name(path, :key)} -iv $#{env_name(path, :iv)} -in #{escape_path(path)} -out #{escape_path(decrypt_to)} -d"
       end
 
       def set_env_vars(input_path)

--- a/spec/cli/encrypt_file_spec.rb
+++ b/spec/cli/encrypt_file_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'fileutils'
+require 'digest'
+
+describe Travis::CLI::EncryptFile do
+  CMD_TARGET = 'README.md'
+
+  before :each do
+    Digest.stub(:hexencode).and_return "randomhex" # to avoid relying on Dir.pwd value for hex
+  end
+
+  after :each do
+    FileUtils.rm_f "#{CMD_TARGET}.enc"
+  end
+
+  example "travis encrypt-file #{CMD_TARGET}" do
+    run_cli('encrypt-file', CMD_TARGET).should be_success
+    File.exists?("#{CMD_TARGET}.enc").should be true
+  end
+end

--- a/spec/support/fake_api.rb
+++ b/spec/support/fake_api.rb
@@ -721,6 +721,56 @@ module Travis
           }]}.to_json
         end
 
+        #### for encrypt_file spec
+        get '/settings/env_vars/' do
+          # p params
+          $params = params
+          {
+            "env_vars":[
+              {
+                "id": "8aa1c74d-dcc4-4e41-9087-1326b7c68abd",
+                "name": "encrypted_randomhex_key",
+                "value": "super_secret_key",
+                "public": false,
+                "repository_id": 891
+              },
+              {
+                "id": "b2ed30b9-622d-4bd7-928b-ba5aad7ba6a1",
+                "name": "encrypted_randomhex_iv",
+                "value": "super_secret_iv",
+                "public": false,
+                "repository_id": 891
+              }
+            ]
+          }.to_json
+        end
+
+        patch '/settings/env_vars/8aa1c74d-dcc4-4e41-9087-1326b7c68abd' do
+          $params = params
+          {
+            "env_var": {
+              "id": "8aa1c74d-dcc4-4e41-9087-1326b7c68abd",
+              "name": "encrypted_randomhex_key",
+              "value": "new_super_secret_key",
+              "public": false,
+              "repository_id": 891
+            }
+          }.to_json
+        end
+
+        patch '/settings/env_vars/b2ed30b9-622d-4bd7-928b-ba5aad7ba6a1' do
+          $params = params
+          {
+            "env_var": {
+              "id": "b2ed30b9-622d-4bd7-928b-ba5aad7ba6a1",
+              "name": "encrypted_randomhex_iv",
+              "value": "new_super_secret_iv",
+              "public": false,
+              "repository_id": 891
+            }
+          }.to_json
+        end
+
         post '/requests' do
           $params = params
           "{}"


### PR DESCRIPTION
FakeAPI is stubbed to satisfy a very small number of calls that
`encrypt-file` command requires.