### PR TITLE
Show Commit short_sha in travis show command

### DIFF
--- a/lib/travis/cli/show.rb
+++ b/lib/travis/cli/show.rb
@@ -19,6 +19,7 @@ module Travis
           entity.color,
           entity.pull_request? ? "pull request" : "push",
           entity.branch_info,
+          entity.commit.short_sha,
           entity.commit.compare_url,
           formatter.duration(entity.duration),
           formatter.time(entity.started_at),
@@ -51,6 +52,7 @@ __END__
 <[[ color("State:         ", :info) ]]><[[ color(%p, :%s) ]]>
 <[[ color("Type:          ", :info) ]]>%s
 <[[ color("Branch:        ", :info) ]]>%s
+<[[ color("Commit:        ", :info) ]]>%s
 <[[ color("Compare URL:   ", :info) ]]>%s
 <[[ color("Duration:      ", :info) ]]>%s
 <[[ color("Started:       ", :info) ]]>%s


### PR DESCRIPTION
Addresses #739 
Useful in mapping a Travis CI build number to a Commit SHA