### PR TITLE
Group command help text

### DIFF
--- a/lib/travis/cli/help.rb
+++ b/lib/travis/cli/help.rb
@@ -26,10 +26,6 @@ module Travis
         end
       end
 
-      def commands
-        CLI.commands.sort_by { |c| c.command_name }
-      end
-
       def cmd_group_header(title)
         say "    #{color(title, :green)}"
       end

--- a/lib/travis/cli/help.rb
+++ b/lib/travis/cli/help.rb
@@ -5,18 +5,52 @@ module Travis
     class Help < Command
       description "helps you out when in dire need of information"
 
+      CommandGroup = Struct.new(:cmds, :header)
+
       def run(command = nil)
         if command
           say CLI.command(command).new.help
         else
+          api_cmds   = CommandGroup.new(api_commands,   'API commands')
+          repo_cmds  = CommandGroup.new(repo_commands,  'Repo commands')
+          other_cmds = CommandGroup.new(other_commands, 'non-API commands')
+
           say "Usage: travis COMMAND ...\n\nAvailable commands:\n\n"
-          commands.each { |c| say "\t#{color(c.command_name, :command).ljust(22)} #{color(c.description, :info)}" }
+          [other_cmds, api_cmds, repo_cmds].each do |cmd_grp|
+            say "    #{cmd_grp.header}"
+            cmd_grp.cmds.each do |cmd|
+              say "        #{color(cmd.command_name, :command).ljust(22)} #{color(cmd.description, :info)}"
+            end
+          end
           say "\nrun `#$0 help COMMAND` for more info"
         end
       end
 
       def commands
         CLI.commands.sort_by { |c| c.command_name }
+      end
+
+      def cmd_group_header(title)
+        say "    #{color(title, :green)}"
+      end
+
+      def api_commands
+        CLI.commands.select do |cmd|
+          cmd.ancestors.include?(CLI::ApiCommand) &&
+          !cmd.ancestors.include?(CLI::RepoCommand)
+        end.sort_by {|c| c.command_name}
+      end
+
+      def repo_commands
+        CLI.commands.select do |cmd|
+          cmd.ancestors.include? CLI::RepoCommand
+        end.sort_by {|c| c.command_name}
+      end
+
+      def other_commands
+        CLI.commands.select do |cmd|
+          !cmd.ancestors.include? CLI::ApiCommand
+        end.sort_by {|c| c.command_name}
       end
     end
   end


### PR DESCRIPTION
Group command help text by each command's function.

Resolves #170.

```sh-session
$ bx ./bin/travis --help
Usage: travis COMMAND ...

Available commands:

    non-API commands
        help           helps you out when in dire need of information
        version        outputs the client version
    API commands
        accounts       displays accounts and their subscription status
        console        interactive shell; requires `pry`
        endpoint       displays or changes the API endpoint
        lint           display warnings for a .travis.yml
        login          authenticates against the API and stores the token
        logout         deletes the stored API token
        monitor        live monitor for what's going on
        raw            makes an (authenticated) API call and prints out the result
        report         generates a report useful for filing issues
        repos          lists repositories the user has certain permissions on
        sync           triggers a new sync with GitHub
        token          outputs the secret API token
        whatsup        lists most recent builds
        whoami         outputs the current user
    Repo commands
        branches       displays the most recent build for each branch
        cache          lists or deletes repository caches
        cancel         cancels a job or build
        disable        disables a project
        enable         enables a project
        encrypt        encrypts values for the .travis.yml
        encrypt-file   encrypts a file and adds decryption steps to .travis.yml
        env            show or modify build environment variables
        history        displays a project's build history
        init           generates a .travis.yml and enables the project
        logs           streams test logs
        open           opens a build or job in the browser
        pubkey         prints out a repository's public key
        requests       lists recent requests
        restart        restarts a build or job
        settings       access repository settings
        setup          sets up an addon or deploy target
        show           displays a build or job
        sshkey         checks, updates or deletes an SSH key
        status         checks status of the latest build

run `./bin/travis help COMMAND` for more info
```