### PR TITLE
Add blurb about persistent login error

### DIFF
--- a/lib/travis/cli/login.rb
+++ b/lib/travis/cli/login.rb
@@ -31,7 +31,13 @@ module Travis
         github.with_token do |token|
           endpoint_config['access_token'] = github_auth(token)
           error("user mismatch: logged in as %p instead of %p" % [user.login, user_login]) if user_login and user.login != user_login
-          error("#{user.login} has not granted Travis CI the required permissions, please log in via #{session.config['host']}") unless user.correct_scopes?
+          unless user.correct_scopes?
+            error(
+              "#{user.login} has not granted Travis CI the required permissions. " \
+              "Please try re-syncing your user data at https://#{session.config['host']}/account/preferences " \
+              "and try logging in via #{session.config['host']}"
+            )
+          end
           success("Successfully logged in as #{user.login}!")
         end
 


### PR DESCRIPTION
Due to API indicating errorneously the user has not granted sufficient
scopes.

When user data falls out of sync, API may indicate the user data not having `correct_scopes`. This results in persistent errors such as #744, which is hard to detect from the users' perspective.

This PR adds a bit more text to the error message to be helpful.