### PR TITLE
Remove runtime dependency on FFI

### DIFF
--- a/lib/travis/cli/api_command.rb
+++ b/lib/travis/cli/api_command.rb
@@ -34,13 +34,15 @@ module Travis
 
       on('--adapter ADAPTER', 'Faraday adapter to use for HTTP requests. If omitted, use Typhoeus if it is installed, ' \
         'and Net::HTTP otherwise. See https://lostisland.github.io/faraday/adapters/ for more info') do |c, adapter|
-        adapter.gsub! '-', '_'
-        require "faraday/adapter/#{adapter}"
-        require 'typhoeus/adapters/faraday' if adapter == 'typhoeus'
-        c.session.faraday_adapter = adapter.to_sym
-      rescue LoadError => e
-        warn "\`--adapter #{adapter}\` is given, but it is not installed. Run \`gem install #{adapter}\` and try again"
-        exit 1
+        begin
+          adapter.gsub! '-', '_'
+          require "faraday/adapter/#{adapter}"
+          require 'typhoeus/adapters/faraday' if adapter == 'typhoeus'
+          c.session.faraday_adapter = adapter.to_sym
+        rescue LoadError => e
+          warn "\`--adapter #{adapter}\` is given, but it is not installed. Run \`gem install #{adapter}\` and try again"
+          exit 1
+        end
       end
 
       def initialize(*)

--- a/lib/travis/cli/api_command.rb
+++ b/lib/travis/cli/api_command.rb
@@ -32,11 +32,15 @@ module Travis
         c.enterprise_name = name || 'default'
       end
 
-      on('--adapter ADAPTER', 'Faraday adapter to use for HTTP requests') do |c, adapter|
+      on('--adapter ADAPTER', 'Faraday adapter to use for HTTP requests. If omitted, use Typhoeus if it is installed, ' \
+        'and Net::HTTP otherwise. See https://lostisland.github.io/faraday/adapters/ for more info') do |c, adapter|
         adapter.gsub! '-', '_'
         require "faraday/adapter/#{adapter}"
         require 'typhoeus/adapters/faraday' if adapter == 'typhoeus'
         c.session.faraday_adapter = adapter.to_sym
+      rescue LoadError => e
+        warn "\`--adapter #{adapter}\` is given, but it is not installed. Run \`gem install #{adapter}\` and try again"
+        exit 1
       end
 
       def initialize(*)

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -412,7 +412,7 @@ Gem::Specification.new do |s|
   s.add_dependency "highline",              "~> 2.0"
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "launchy",               "~> 2.1", "< 2.5.0"
-  s.add_dependency "json",                  "~> 2.3"
+  s.add_dependency "json_pure",             "~> 2.3"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_development_dependency "rspec",     "~> 2.12"
   s.add_development_dependency "rspec-its"

--- a/travis.gemspec
+++ b/travis.gemspec
@@ -412,7 +412,6 @@ Gem::Specification.new do |s|
   s.add_dependency "highline",              "~> 2.0"
   s.add_dependency "gh",                    "~> 0.13"
   s.add_dependency "launchy",               "~> 2.1", "< 2.5.0"
-  s.add_dependency "typhoeus",              "~> 0.6", ">= 0.6.8"
   s.add_dependency "json",                  "~> 2.3"
   s.add_dependency "pusher-client",         "~> 0.4"
   s.add_development_dependency "rspec",     "~> 2.12"


### PR DESCRIPTION
This is the only native extension we need, and removing it should simply some installation issues.

To name a few:
#273 
#489 
#512 
#558 
#568 