### PR TITLE
Fix permissions check in `travis env set`

### DIFF
--- a/lib/travis/cli/env.rb
+++ b/lib/travis/cli/env.rb
@@ -15,7 +15,7 @@ module Travis
       def setup
         super
         authenticate
-        error "not allowed to access environment variables for #{color(repository.slug, :bold)}" unless repository.admin?
+        error "not allowed to access environment variables for #{color(repository.slug, :bold)}" unless repository.push?
       end
 
       def set(name, value)


### PR DESCRIPTION
To set env vars via API or UI only requires push permission on the repo, but the CLI checks for admin permission, blocking users from interacting with their repo settings in this way. This fixes the permissions-check here to match what is done on the server.

Fixes #609 