### PR TITLE
Update README.md to include Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2073,7 +2073,7 @@ Ubuntu:
 
 Fedora:
 
-    $ sudo yum install ruby ruby-devel
+    $ sudo dnf install ruby ruby-devel redhat-rpm-config libffi-devel
 
 Arch Linux:
 


### PR DESCRIPTION
As mentioned on issue 602: https://github.com/travis-ci/travis.rb/issues/602
Fedora requires the additional packages: libffi-devel and redhat-rpm-config
In addition dnf is now the default package manager for Fedora since Fedora 22