### PR TITLE
Use portable "command -v" to detect installed programs

### DIFF
--- a/lib/travis/tools/system.rb
+++ b/lib/travis/tools/system.rb
@@ -76,7 +76,7 @@ module Travis
       def has?(command)
         return false unless unix?
         @has ||= {}
-        @has.fetch(command) { @has[command] = system "which #{command} 2>/dev/null >/dev/null" }
+        @has.fetch(command) { @has[command] = system "command -v #{command} 2>/dev/null >/dev/null" }
       end
 
       def running?(app)


### PR DESCRIPTION
The "which" utility is not guaranteed to be installed either, and if it is, its behavior is not portable either.

Conversely, the "command -v" shell builtin is required to exist in all POSIX 2008 compliant shells, and is thus guaranteed to work everywhere.

Examples of open-source shells likely to be installed as /bin/sh on Linux, which implement the 11-year-old standard: ash, bash, busybox, dash, ksh, mksh and zsh.

See:
https://mywiki.wooledge.org/BashFAQ/081
https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then/85250#85250