### PR TITLE
fix list_github_token

### DIFF
--- a/lib/travis/cli/login.rb
+++ b/lib/travis/cli/login.rb
@@ -62,7 +62,7 @@ module Travis
             g.auto_password = auto_password
             g.github_login  = user_login
             g.check_token   = !skip_token_check?
-            g.drop_token    = list_github_token ? false : true
+            g.drop_token    = !list_github_token
             g.ask_login     = proc { ask("Username: ") }
             g.ask_password  = proc { |user| ask("Password for #{user}: ") { |q| q.echo = "*" } }
             g.ask_otp       = proc { |user| ask("Two-factor authentication code for #{user}: ") }

--- a/lib/travis/cli/login.rb
+++ b/lib/travis/cli/login.rb
@@ -62,7 +62,7 @@ module Travis
             g.auto_password = auto_password
             g.github_login  = user_login
             g.check_token   = !skip_token_check?
-            g.drop_token    = true
+            g.drop_token    = list_github_token ? false : true
             g.ask_login     = proc { ask("Username: ") }
             g.ask_password  = proc { |user| ask("Password for #{user}: ") { |q| q.echo = "*" } }
             g.ask_otp       = proc { |user| ask("Two-factor authentication code for #{user}: ") }


### PR DESCRIPTION
Currently, with --github-token=x gives "Faraday::UnauthorizedError: the server responded with status 401" error.
I found that travis cli with password always deletes the token. i.e.
`GitHub API: DELETE /authorizations/483247674`
so, with --list-github-token, we should not remove the github token.
fixes for:
```
travis login --list-github-token
travis login --github-token=x to login
```