### PR TITLE
Fix 'travis monitor' on Linux

### DIFF
--- a/lib/travis/tools/notification.rb
+++ b/lib/travis/tools/notification.rb
@@ -24,7 +24,6 @@ module Travis
       end
 
       class Dummy
-        BIN_PATH = Assets['Travis CI.app/Contents/MacOS/Travis CI']
         def notify(title, body)
         end
 


### PR DESCRIPTION
Just loading notification.rb causes the Dummy class constructor to fail, because of non-existing path in Asset. This seems to be caused by some recent changes in asset.rb, but the proper fix is to not rely on non-existing path.

Before this fix the error message is:
```
Traceback (most recent call last):
 18: from /home/user/bin/travis:23:in `<main>'
 17: from /home/user/bin/travis:23:in `load'
 16: from /home/user/.gem/ruby/gems/travis-1.10.0/bin/travis:18:in `<top (required)>'
 15: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/cli.rb:62:in `run'
 14: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/cli.rb:69:in `command'
 13: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/cli.rb:69:in `const_get'
 12: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
 11: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
 10: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/cli/monitor.rb:2:in `<top (required)>'
  9: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
  8: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
  7: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/notification.rb:6:in `<top (required)>'
  6: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/notification.rb:7:in `<module:Travis>'
  5: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/notification.rb:8:in `<module:Tools>'
  4: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/notification.rb:26:in `<module:Notification>'
  3: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/notification.rb:27:in `<class:Dummy>'
  2: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/assets.rb:9:in `asset_path'
  1: from /home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/assets.rb:9:in `tap'
/home/user/.gem/ruby/gems/travis-1.10.0/lib/travis/tools/assets.rb:10:in `block in asset_path': Travis CI.app/Contents/MacOS/Travis CI (Travis::Client::AssetNotFound)
```