### PR TITLE
fix typo (cancelled)

### DIFF
--- a/lib/travis/client/states.rb
+++ b/lib/travis/client/states.rb
@@ -3,7 +3,7 @@ require 'travis/client'
 module Travis
   module Client
     module States
-      STATES  = %w[created queued received started passed failed errored canceled ready]
+      STATES  = %w[created queued received started passed failed errored cancelled ready]
 
       def ready?
         state == 'ready'


### PR DESCRIPTION
There is a typo in status.rb and cause an error for "cancelled" state:

<pre>
$ travis logs --repo ethereum/go-ethereum 7542
displaying logs for ethereum/go-ethereum#7542.1
unknown state "cancelled" for #&ltTravis::Client::Job: ethereum/go-ethereum#7542.1&gt
</pre>
